### PR TITLE
fix: resolve clangd 'expected exactly one compiler job' error (#13)

### DIFF
--- a/src/createProperties.js
+++ b/src/createProperties.js
@@ -418,6 +418,10 @@ async function CreateProperties(force = false) {
                 args.push('-D__MQL5_BUILD__');
             }
 
+            // -c tells the driver to compile only (no linking), producing
+            // exactly one compiler job.  Some clangd versions fail with
+            // "fe_expected_compiler_job" when this is missing.
+            args.push('-c');
             args.push(filePath);
 
             return {
@@ -619,7 +623,9 @@ async function CreateProperties(force = false) {
             'member_decl_does_not_match',
             'ovl_no_oper',
             // MQL const semantics differ from C++ - const params can be reassigned
-            'typecheck_assign_const'
+            'typecheck_assign_const',
+            // Clangd driver error when compile command produces multiple jobs
+            'fe_expected_compiler_job'
         ];
 
         let finalSuppressions = baseSuppressions;
@@ -666,6 +672,8 @@ Hover:
 
 CompileFlags:
   Add:
+    # Compile only – ensures the driver produces exactly one compiler job
+    - -c
     # Suppress all warnings in .clangd config; targeted -Wno-* flags are already set in baseFlags
     - -Wno-everything
 


### PR DESCRIPTION
## Summary
Fixes #13 — clangd reports **\\Unable to handle compilation, expected exactly one compiler job\\** on valid \\.mq5\\ files.

## Root Cause
The \\compile_commands.json\\ entries generated by the extension were missing the **\\-c\\** flag (compile-only). Without it, some clangd versions interpret the compile command as producing multiple driver jobs (compile + link), triggering the fatal \\e_expected_compiler_job\\ error.

## Changes
- **Added \\-c\\ flag to \\compile_commands.json\\ arguments** — Explicitly tells the clang driver to compile only (no linking), ensuring exactly one compilation job. This is standard practice (e.g., CMake always includes it).
- **Added \\-c\\ to \\.clangd\\ \\CompileFlags.Add\\** — Safety net for users who haven''t regenerated their \\compile_commands.json\\ yet.
- **Added \\e_expected_compiler_job\\ to the suppression list** — Belt-and-suspenders for stale configurations.

## Testing
All 95 unit tests pass with no regressions.