### PR TITLE
feat: add anonymous usage telemetry with opt-out

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,11 @@
                         "Automatically merge existing suppressions",
                         "Always overwrite the .clangd file"
                     ]
+                },
+                "mql_tools.telemetry.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Send anonymous usage statistics to help improve MQL Clangd. **No personal data, file names, paths, or code is ever collected** — only which commands and features are used, and whether compilation succeeds. You can also disable all extension telemetry globally via `telemetry.telemetryLevel`."
                 }
             }
         },

--- a/src/extension.js
+++ b/src/extension.js
@@ -54,6 +54,7 @@ const {
     cleanupBatchFile
 } = require('./wineHelper');
 const logTailer = require('./logTailer');
+const telemetry = require('./telemetry');
 
 
 // =============================================================================
@@ -759,6 +760,13 @@ async function Compile(rt, context) {
     if (hasErrors) {
         await vscode.commands.executeCommand('workbench.panel.markers.view.focus');
     }
+
+    telemetry.track('compile_result', {
+        mode: rt === 0 ? 'check' : rt === 1 ? 'compile' : 'script',
+        ext:  extension.slice(1), // 'mq4', 'mq5', or 'mqh' — no path
+        ok:   !hasErrors,
+        wine: isWineEnabled(vscode.workspace.getConfiguration('mql_tools'))
+    });
 }
 
 function replaceLog(str, f) {
@@ -2137,6 +2145,8 @@ function activate(context) {
     diagnosticCollection = vscode.languages.createDiagnosticCollection('mql');
     outputChannel = vscode.window.createOutputChannel('MQL', 'mql-output');
 
+    telemetry.init(context);
+
     const extensionId = 'ngsoftware.mql-tools';
     const currentVersion = vscode.extensions.getExtension(extensionId)?.packageJSON.version;
     const previousVersion = context.globalState.get('mql-tools.version');
@@ -2181,6 +2191,15 @@ function activate(context) {
         });
     }
 
+    // Track anonymous activation snapshot (feature flags only, no PII)
+    telemetry.track('activate', {
+        wine:             config.get('Wine.Enabled', false),
+        lightweight_diag: config.get('Diagnostics.Lightweight', true),
+        auto_check:       config.get('AutoCheck.Enabled', false),
+        check_on_save:    config.get('CheckOnSave', true),
+        first_install:    previousVersion === undefined
+    });
+
     // Wait for environment to stabilize before migration check
     sleep(2000).then(() => {
         if (previousVersion !== currentVersion) {
@@ -2194,11 +2213,11 @@ function activate(context) {
         }
     });
 
-    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.checkFile', () => Compile(0, context)));
-    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.compileFile', () => Compile(1, context)));
-    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.compileScript', () => Compile(2, context)));
-    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.help', (keyword, version) => Help(keyword, version)));
-    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.offlineHelp', () => OfflineHelp()));
+    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.checkFile', () => { telemetry.track('command', { name: 'check' }); return Compile(0, context); }));
+    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.compileFile', () => { telemetry.track('command', { name: 'compile' }); return Compile(1, context); }));
+    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.compileScript', () => { telemetry.track('command', { name: 'compile_script' }); return Compile(2, context); }));
+    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.help', (keyword, version) => { telemetry.track('command', { name: 'help' }); return Help(keyword, version); }));
+    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.offlineHelp', () => { telemetry.track('command', { name: 'offline_help' }); return OfflineHelp(); }));
 
     // Compile target commands
     context.subscriptions.push(vscode.commands.registerCommand('mql_tools.selectCompileTarget', async () => {
@@ -2300,6 +2319,7 @@ function activate(context) {
         }
     }));
     context.subscriptions.push(vscode.commands.registerCommand('mql_tools.configurations', async () => {
+        telemetry.track('command', { name: 'create_config' });
         await CreateProperties();
         try {
             await vscode.commands.executeCommand('clangd.restart');
@@ -2320,7 +2340,7 @@ function activate(context) {
     context.subscriptions.push(vscode.commands.registerCommand('mql_tools.openInME', (uri) => OpenFileInMetaEditor(uri)));
     context.subscriptions.push(vscode.commands.registerCommand('mql_tools.openTradingTerminal', () => OpenTradingTerminal()));
     context.subscriptions.push(vscode.commands.registerCommand('mql_tools.commentary', () => CreateComment()));
-    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.toggleTerminalLog', () => logTailer.toggle()));
+    context.subscriptions.push(vscode.commands.registerCommand('mql_tools.toggleTerminalLog', () => { telemetry.track('command', { name: 'toggle_log' }); return logTailer.toggle(); }));
 
     // LiveLog commands for real-time logging
     context.subscriptions.push(vscode.commands.registerCommand('mql_tools.installLiveLog', async () => {
@@ -2372,6 +2392,7 @@ function activate(context) {
             }
             logTailer.updateStatusBar();
             vscode.window.showInformationMessage(`Switched to ${selected.label} mode`);
+            telemetry.track('command', { name: 'switch_log_mode', mode: selected.mode });
         }
     }));
 

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -1,0 +1,137 @@
+'use strict';
+
+// =============================================================================
+// TELEMETRY MODULE
+// Anonymous usage analytics via PostHog.
+//
+// DEVELOPER SETUP:
+//   Fill in POSTHOG_ENDPOINT and POSTHOG_API_KEY before publishing.
+//   Users opt out via: Settings → mql_tools.telemetry.enabled = false
+//   The global VS Code telemetry switch (telemetry.telemetryLevel) is also
+//   respected automatically.
+//
+// DATA COLLECTED (anonymous, no PII):
+//   - Extension version, VS Code version, OS platform
+//   - Which commands are invoked
+//   - Compile/check results: success/fail, file type (mq4/mq5/mqh), Wine mode
+//   - Active feature flags at startup (Wine, lightweight diagnostics, etc.)
+//
+// NOT COLLECTED:
+//   - File names, paths, workspace names, code content
+// =============================================================================
+
+const https = require('https');
+const crypto = require('crypto');
+const vscode = require('vscode');
+
+// --- Developer constants (fill before publishing) ---
+const POSTHOG_ENDPOINT = 'https://app.posthog.com/batch/'; // replace with your host
+const POSTHOG_API_KEY  = 'phc_REPLACE_WITH_YOUR_KEY';
+
+const FLUSH_INTERVAL_MS = 30_000; // send queued events every 30 s
+const MAX_QUEUE_SIZE    = 50;     // send immediately when queue reaches this
+
+let _sessionId   = null; // random UUID, generated per-session, never persisted
+let _extVersion  = 'unknown';
+let _queue       = [];
+let _flushTimer  = null;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function _isEnabled() {
+    // Respect VS Code's global telemetry level (off / error / crash / all)
+    if (vscode.env.isTelemetryEnabled === false) return false;
+
+    const cfg = vscode.workspace.getConfiguration('mql_tools');
+    return cfg.get('telemetry.enabled', true);
+}
+
+function _send(batch) {
+    if (!POSTHOG_API_KEY || POSTHOG_API_KEY.startsWith('phc_REPLACE')) return;
+
+    const body = JSON.stringify({ api_key: POSTHOG_API_KEY, batch });
+    let hostname, basePath;
+    try {
+        const u = new URL(POSTHOG_ENDPOINT);
+        hostname = u.hostname;
+        basePath = u.pathname;
+    } catch (_) {
+        return;
+    }
+
+    // Fire-and-forget: schedule after current JS turn so it never blocks
+    setImmediate(() => {
+        try {
+            const req = https.request(
+                {
+                    hostname,
+                    port: 443,
+                    path: basePath,
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Content-Length': Buffer.byteLength(body)
+                    }
+                },
+                (res) => { res.resume(); } // drain response to free socket
+            );
+            req.on('error', () => {}); // silently swallow network errors
+            req.write(body);
+            req.end();
+        } catch (_) {}
+    });
+}
+
+function _flush() {
+    if (_queue.length === 0) return;
+    _send(_queue.splice(0)); // drain queue atomically
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialise telemetry. Call once from activate().
+ * @param {import('vscode').ExtensionContext} context
+ */
+function init(context) {
+    _sessionId  = crypto.randomUUID();
+    _extVersion = context.extension?.packageJSON?.version ?? 'unknown';
+
+    // Flush on a timer; unref() so it won't keep the Node process alive
+    _flushTimer = setInterval(_flush, FLUSH_INTERVAL_MS);
+    if (_flushTimer.unref) _flushTimer.unref();
+
+    // Flush remaining events when the extension deactivates
+    context.subscriptions.push({ dispose: () => { clearInterval(_flushTimer); _flush(); } });
+}
+
+/**
+ * Record an anonymous event. Fire-and-forget – never throws.
+ * @param {string} event   PostHog event name
+ * @param {Record<string,unknown>} [props]  Additional properties (no PII)
+ */
+function track(event, props = {}) {
+    try {
+        if (!_isEnabled()) return;
+
+        _queue.push({
+            event,
+            distinct_id: _sessionId,
+            properties: {
+                ext_v:    _extVersion,
+                vscode_v: vscode.version,
+                platform: process.platform,
+                ...props
+            },
+            timestamp: new Date().toISOString()
+        });
+
+        if (_queue.length >= MAX_QUEUE_SIZE) setImmediate(_flush);
+    } catch (_) {}
+}
+
+module.exports = { init, track };


### PR DESCRIPTION
Adds a lightweight, non-blocking PostHog telemetry module to track
how users interact with the extension, helping guide future development.

What is tracked (all anonymous, no PII):
- Extension activation with active feature flags snapshot
  (Wine mode, lightweight diagnostics, AutoCheck, CheckOnSave)
- Command usage: check, compile, compile_script, create_config,
  help, toggle_log, switch_log_mode
- Compile results: mode (check/compile/script), file type (mq4/mq5/mqh),
  success/failure, Wine in use

What is never collected:
- File names, paths, workspace names, or any code content

Implementation details:
- Events are batched in memory and sent every 30 s or when 50 events
  accumulate, flushed on deactivate
- HTTP requests are fire-and-forget via setImmediate — no blocking
- All network errors are silently swallowed
- Session ID is a random UUID generated per session, never persisted
- Respects both the global VS Code telemetry.telemetryLevel setting
  and the new mql_tools.telemetry.enabled extension setting
- Developer must fill in POSTHOG_ENDPOINT and POSTHOG_API_KEY in
  src/telemetry.js before publishing

https://claude.ai/code/session_012BZN6v9zPYec5B5PwDWPz7