### PR TITLE
feat: debugger improvements — smarter detection, expression watches, batch I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 - **Logpoints**: Breakpoints with a log message emit to the Debug Console without pausing the EA. Supports `{expression}` interpolation with type-aware formatting for `int`, `double`, `string`, `bool`, `datetime`, and `enum` types.
 - **Clickable MQL Online Docs**: Hover tooltips now include a direct link to the MQL5 online documentation for built-in functions.
 - **Descriptive Breakpoint Messages**: Adjusted and unverified breakpoints now show descriptive status messages in the VS Code UI.
+- **Smarter Variable Detection**: The debugger now uses heuristics to prioritize which variables to watch at each breakpoint:
+  - **Assignment-proximity scoring**: Variables assigned on or near the breakpoint line are ranked higher than distant declarations.
+  - **Control-flow awareness**: Variables from enclosing `if`/`for`/`while`/`switch` conditions are automatically included.
+  - **Function call arguments**: Variables passed as arguments to function calls near the breakpoint are detected.
+  - **Auto-expand small structs**: Struct/class members (<=8 primitive fields) are expanded at default detail level without needing Deep Analysis.
+- **Expression Watches** (`// @watch:type expr`): Watch arbitrary MQL expressions, not just variables. The expression is evaluated at the breakpoint and its value shown in the Variables panel. Function calls are validated against a built-in allowlist of read-only MQL functions. Use `// @watch!:type expr` to bypass safety checks for advanced use cases.
+- **Variable Timeline**: Expand any variable in the Variables panel to see its value history across multiple hits of the same breakpoint.
+- **Batch I/O**: Debug probes now batch all writes into a single `FileWriteString+FileFlush` per breakpoint hit, reducing file I/O by up to 10x for breakpoints with many watches.
+- **CodeLens Watch Suggestions**: Breakpoint lines without a `@watch` annotation show a clickable "Add @watch" CodeLens for quick annotation insertion.
 
 ### Bug Fixes
 - **Mid-session logpoints**: Logpoints added after compilation now work without recompiling — every probe checks the logpoint flag at runtime.

--- a/files/MqlDebug.mqh
+++ b/files/MqlDebug.mqh
@@ -198,6 +198,31 @@ void MqlDebugWrite(string structured) {
 }
 
 //+------------------------------------------------------------------+
+//| Batch I/O — accumulate lines and write once                      |
+//+------------------------------------------------------------------+
+string __mqldbg_batch = "";
+
+void MqlDebugBatchStart() { __mqldbg_batch = ""; }
+
+void MqlDebugBatchAdd(string structured) {
+  __mqldbg_batch += structured + "\n";
+}
+
+void MqlDebugBatchFlush() {
+  if (__mqldbg_batch == "") return;
+  if (!__dbgState.IsDebugInitialized())
+    MqlDebugInit();
+  if (__dbgState.GetDebugHandle() == INVALID_HANDLE)
+    return;
+  MqlDebugRotate();
+  if (__dbgState.GetDebugHandle() == INVALID_HANDLE)
+    return;
+  FileWriteString(__dbgState.GetDebugHandle(), __mqldbg_batch);
+  FileFlush(__dbgState.GetDebugHandle());
+  __mqldbg_batch = "";
+}
+
+//+------------------------------------------------------------------+
 //| Escape strings for DBG logging                                   |
 //+------------------------------------------------------------------+
 string MqlDebugEscape(string val) {
@@ -254,6 +279,35 @@ string MqlDebugEscape(string val) {
 #define MQL_DBG_WATCH(varName, val) MQL_DBG_WATCH_DBL(varName, val)
 
 //+------------------------------------------------------------------+
+//| Batch-mode macros — same output format, accumulated in buffer    |
+//+------------------------------------------------------------------+
+#define MQL_DBG_BBREAK(label) \
+    MqlDebugBatchAdd("DBG|" + MqlDebugTime() + "|" + __FILE__ + "|" + __FUNCTION__ + "|" + IntegerToString(__LINE__) + "|BREAK|" + MqlDebugEscape(label))
+
+#define MQL_DBG_BWATCH_INT(varName, val) \
+    MqlDebugBatchAdd("DBG|" + MqlDebugTime() + "|" + __FILE__ + "|" + __FUNCTION__ + "|" + IntegerToString(__LINE__) + "|WATCH|" + MqlDebugEscape(varName) + "|int|" + IntegerToString((long)(val)))
+
+#define MQL_DBG_BWATCH_LONG(varName, val) \
+    MqlDebugBatchAdd("DBG|" + MqlDebugTime() + "|" + __FILE__ + "|" + __FUNCTION__ + "|" + IntegerToString(__LINE__) + "|WATCH|" + MqlDebugEscape(varName) + "|long|" + IntegerToString((long)(val)))
+
+#define MQL_DBG_BWATCH_DBL(varName, val) \
+    MqlDebugBatchAdd("DBG|" + MqlDebugTime() + "|" + __FILE__ + "|" + __FUNCTION__ + "|" + IntegerToString(__LINE__) + "|WATCH|" + MqlDebugEscape(varName) + "|double|" + DoubleToString((double)(val), 8))
+
+#define MQL_DBG_BWATCH_STR(varName, val) \
+    MqlDebugBatchAdd("DBG|" + MqlDebugTime() + "|" + __FILE__ + "|" + __FUNCTION__ + "|" + IntegerToString(__LINE__) + "|WATCH|" + MqlDebugEscape(varName) + "|string|" + MqlDebugEscape(val))
+
+#define MQL_DBG_BWATCH_BOOL(varName, val) \
+    MqlDebugBatchAdd("DBG|" + MqlDebugTime() + "|" + __FILE__ + "|" + __FUNCTION__ + "|" + IntegerToString(__LINE__) + "|WATCH|" + MqlDebugEscape(varName) + "|bool|" + ((val) ? "true" : "false"))
+
+#define MQL_DBG_BWATCH_DATETIME(varName, val) \
+    MqlDebugBatchAdd("DBG|" + MqlDebugTime() + "|" + __FILE__ + "|" + __FUNCTION__ + "|" + IntegerToString(__LINE__) + "|WATCH|" + MqlDebugEscape(varName) + "|datetime|" + TimeToString((datetime)(val), TIME_DATE | TIME_SECONDS))
+
+#define MQL_DBG_BWATCH(varName, val) MQL_DBG_BWATCH_DBL(varName, val)
+
+#define MQL_DBG_BLOG(msg) \
+    MqlDebugBatchAdd("DBG|" + MqlDebugTime() + "|" + __FILE__ + "|" + __FUNCTION__ + "|" + IntegerToString(__LINE__) + "|LOG|" + MqlDebugEscape(msg))
+
+//+------------------------------------------------------------------+
 //| ARRAY watch macros — emit each element as a separate WATCH line  |
 //| with varName[index] naming.  Capped at MQLDEBUG_MAX_ARRAY_ELEMS |
 //| to prevent flooding the log file on large arrays.                |
@@ -283,6 +337,33 @@ string MqlDebugEscape(string val) {
     MQL_DBG_WATCH_INT(varName + ".size", ArraySize(arr)); \
     for (int __i = 0; __i < __n; __i++) \
       MQL_DBG_WATCH_STR(varName + "[" + IntegerToString(__i) + "]", arr[__i]); }
+
+//+------------------------------------------------------------------+
+//| Batch-mode ARRAY macros                                          |
+//+------------------------------------------------------------------+
+#define MQL_DBG_BWATCH_ARRAY_INT(varName, arr) \
+  { int __n = MathMin(ArraySize(arr), MQLDEBUG_MAX_ARRAY_ELEMS); \
+    MQL_DBG_BWATCH_INT(varName + ".size", ArraySize(arr)); \
+    for (int __i = 0; __i < __n; __i++) \
+      MQL_DBG_BWATCH_INT(varName + "[" + IntegerToString(__i) + "]", arr[__i]); }
+
+#define MQL_DBG_BWATCH_ARRAY_DBL(varName, arr) \
+  { int __n = MathMin(ArraySize(arr), MQLDEBUG_MAX_ARRAY_ELEMS); \
+    MQL_DBG_BWATCH_INT(varName + ".size", ArraySize(arr)); \
+    for (int __i = 0; __i < __n; __i++) \
+      MQL_DBG_BWATCH_DBL(varName + "[" + IntegerToString(__i) + "]", arr[__i]); }
+
+#define MQL_DBG_BWATCH_ARRAY_LONG(varName, arr) \
+  { int __n = MathMin(ArraySize(arr), MQLDEBUG_MAX_ARRAY_ELEMS); \
+    MQL_DBG_BWATCH_INT(varName + ".size", ArraySize(arr)); \
+    for (int __i = 0; __i < __n; __i++) \
+      MQL_DBG_BWATCH_LONG(varName + "[" + IntegerToString(__i) + "]", arr[__i]); }
+
+#define MQL_DBG_BWATCH_ARRAY_STR(varName, arr) \
+  { int __n = MathMin(ArraySize(arr), MQLDEBUG_MAX_ARRAY_ELEMS); \
+    MQL_DBG_BWATCH_INT(varName + ".size", ArraySize(arr)); \
+    for (int __i = 0; __i < __n; __i++) \
+      MQL_DBG_BWATCH_STR(varName + "[" + IntegerToString(__i) + "]", arr[__i]); }
 
 //+------------------------------------------------------------------+
 //| PAUSE — spin-wait at breakpoint until VS Code sends CONTINUE     |

--- a/media/tabs/tab-debugger.html
+++ b/media/tabs/tab-debugger.html
@@ -66,16 +66,24 @@
                 </ul>
 
                 <h3>What Variables are Tracked?</h3>
-                <p>To keep performance high, the debugger smartly tracks variables based on your settings:</p>
+                <p>The debugger uses smart heuristics to automatically prioritize the most relevant variables at each breakpoint:</p>
                 <ul>
-                    <li><strong>Locals & Parameters:</strong> Tracks local variables and function parameters accessed
-                        near your breakpoints.</li>
+                    <li><strong>Locals & Parameters:</strong> Tracks local variables and function parameters in scope,
+                        ranked by proximity — variables assigned on or near the breakpoint line appear first.</li>
+                    <li><strong>Control-Flow Variables:</strong> Variables from enclosing <span class="code-inline">if</span>,
+                        <span class="code-inline">for</span>, <span class="code-inline">while</span>, and
+                        <span class="code-inline">switch</span> conditions are automatically included.</li>
+                    <li><strong>Function Call Arguments:</strong> Variables passed as arguments to function calls on or near
+                        the breakpoint line are detected and watched.</li>
+                    <li><strong>Small Struct Expansion:</strong> Struct and class types with 8 or fewer primitive fields
+                        are automatically expanded — no Deep Analysis needed.</li>
                     <li><strong>Class Members:</strong> Monitors fields belonging to the current class instance (<span
                             class="code-inline">this</span>).</li>
-                    <li><strong>Deep Analysis (Optional):</strong> Want more details? Enable <span
-                            class="code-inline">mql_tools.Debug.DetailLevel = "deepAnalysis"</span> in your VS Code
-                        settings. This will additionally track global primitives and recursively expand object fields.
-                    </li>
+                    <li><strong>Deep Analysis (Optional):</strong> Want even more? Enable <span
+                            class="code-inline">mql_tools.Debug.DetailLevel = "deepAnalysis"</span> to additionally
+                        track global primitives, input variables, and recursively expand all object fields.</li>
+                    <li><strong>Variable Timeline:</strong> Expand any variable in the Variables panel to see its value
+                        history across multiple hits of the same breakpoint.</li>
                     <li><strong>Breakpoint Info:</strong> Provides metadata such as hit counts, source file names, line
                         numbers, and timestamps.</li>
                 </ul>
@@ -156,6 +164,32 @@ void OnTick()
                             auto-detected locals when this breakpoint is hit.
                         </div>
                     </li>
+                    <li>
+                        <strong>Expression Watches</strong> (<span class="code-inline">// @watch:type expr</span>):
+                        Watch arbitrary MQL expressions — not just variable names. Specify the return type
+                        and the expression to evaluate:
+                        <div class="highlight-box">
+<pre style="margin:0; font-family: var(--vscode-editor-font-family), monospace; font-size: 0.9em; line-height: 1.5;">
+// @watch:double SymbolInfoDouble(_Symbol, SYMBOL_ASK)
+// @watch:int    OrdersTotal()
+// @watch:double MathAbs(ask - bid)
+Print("tick");   // &lt;— breakpoint set here</pre>
+                            The expression is injected into the compiled code and evaluated at
+                            the breakpoint. Function calls are validated against a built-in allowlist
+                            of read-only MQL functions (market data, account info, math, etc.).
+                        </div>
+                        <div class="warn-box">
+                            <strong>Unrestricted mode:</strong> Use <span class="code-inline">// @watch!:type expr</span>
+                            (with <span class="code-inline">!</span>) to bypass the safety allowlist and call any function.
+                            Use with caution in shared codebases — the expression is compiled and executed verbatim.
+                        </div>
+                    </li>
+                    <li>
+                        <strong>CodeLens Watch Suggestions:</strong>
+                        When a breakpoint is set on a line without a nearby <span class="code-inline">@watch</span>
+                        annotation, a clickable <em>"Add @watch annotation"</em> lens appears above the line.
+                        Click it to insert a template annotation ready for you to fill in.
+                    </li>
                     <li><strong>Call Stack Tracking:</strong> Functions containing breakpoints automatically report
                         <span class="code-inline">ENTER</span>/<span class="code-inline">EXIT</span> events so the
                         dashboard shows a live call stack.
@@ -176,9 +210,10 @@ void OnTick()
                         instruction level. All stepping actions behave like <strong>Continue</strong> — they resume to
                         the next breakpoint. To inspect intermediate state, set additional breakpoints on the lines you
                         want to observe.</li>
-                    <li><strong>No Expression Evaluation:</strong> The Debug Console does not support evaluating
-                        arbitrary MQL expressions at runtime. Use <span class="code-inline">// @watch</span> annotations
-                        or enable Deep Analysis to capture the variables you need.</li>
+                    <li><strong>No Interactive Expression Evaluation:</strong> The Debug Console does not support typing
+                        arbitrary expressions at runtime. However, you can pre-declare expression watches using
+                        <span class="code-inline">// @watch:type expr</span> annotations — these are compiled into the
+                        debug build and evaluated at each breakpoint hit.</li>
                 </ul>
             </div>
 

--- a/src/debugAdapter.js
+++ b/src/debugAdapter.js
@@ -404,10 +404,11 @@ class MqlDebugAdapter extends EventEmitter {
             } else {
                 watches = this._store.latestWatchList;
             }
+            const hitLabel = hit ? hit.label : '';
             let refId = 1000;
             variables = watches.map(w => {
                 const histRef = refId++;
-                this._historyRefMap.set(histRef, w.varName);
+                this._historyRefMap.set(histRef, { varName: w.varName, label: hitLabel });
                 return {
                     name: w.varName,
                     value: String(w.value),
@@ -433,8 +434,8 @@ class MqlDebugAdapter extends EventEmitter {
             }
         } else if (ref >= 1000 && this._historyRefMap && this._historyRefMap.has(ref)) {
             // Variable history expansion — show value timeline
-            const varName = this._historyRefMap.get(ref);
-            const history = this._store.getVariableHistory(varName, 15);
+            const { varName, label: bpLabel } = this._historyRefMap.get(ref);
+            const history = this._store.getVariableHistory(varName, 15, bpLabel);
             const histHint = { kind: 'property', attributes: ['readOnly'] };
             variables = history.map((h, i) => ({
                 name: `#${i + 1}`,

--- a/src/debugAdapter.js
+++ b/src/debugAdapter.js
@@ -49,6 +49,8 @@ class MqlDebugAdapter extends EventEmitter {
         this._breakpointsConfigured = false;
         /** @type {ReturnType<typeof setTimeout>|null} debounce timer for BP config writes */
         this._reinstrumentTimer = null;
+        /** Maps variablesReference IDs (>=1000) to variable names for history expansion */
+        this._historyRefMap = new Map();
 
         // onDidSendMessage is required by VS Code's DebugAdapter interface.
         // We expose it as an EventEmitter event named 'message'.
@@ -393,24 +395,27 @@ class MqlDebugAdapter extends EventEmitter {
         let variables = [];
         if (ref === 1) {
             // Watches scope — latest watch values from the most recent hit
+            // Each variable is expandable to show its value history
+            this._historyRefMap = new Map(); // reset on each variables request for ref=1
             const hit = this._store.latestHit;
+            let watches;
             if (hit && hit.watches && hit.watches.length) {
-                variables = hit.watches.map(w => ({
-                    name: w.varName,
-                    value: String(w.value),
-                    type: w.varType,
-                    presentationHint: { kind: 'data', attributes: ['readOnly'] },
-                    variablesReference: 0,
-                }));
+                watches = hit.watches;
             } else {
-                variables = this._store.latestWatchList.map(w => ({
+                watches = this._store.latestWatchList;
+            }
+            let refId = 1000;
+            variables = watches.map(w => {
+                const histRef = refId++;
+                this._historyRefMap.set(histRef, w.varName);
+                return {
                     name: w.varName,
                     value: String(w.value),
                     type: w.varType,
                     presentationHint: { kind: 'data', attributes: ['readOnly'] },
-                    variablesReference: 0,
-                }));
-            }
+                    variablesReference: histRef,
+                };
+            });
         } else if (ref === 2) {
             // Breakpoint Info scope — metadata about the current hit
             const hit = this._store.latestHit;
@@ -426,6 +431,17 @@ class MqlDebugAdapter extends EventEmitter {
                     { name: 'Total Hits', value: String(this._store.hits.length), type: 'int', presentationHint: infoHint, variablesReference: 0 },
                 ];
             }
+        } else if (ref >= 1000 && this._historyRefMap && this._historyRefMap.has(ref)) {
+            // Variable history expansion — show value timeline
+            const varName = this._historyRefMap.get(ref);
+            const history = this._store.getVariableHistory(varName, 15);
+            const histHint = { kind: 'property', attributes: ['readOnly'] };
+            variables = history.map((h, i) => ({
+                name: `#${i + 1}`,
+                value: `${h.value}  [${h.timestamp}]`,
+                presentationHint: histHint,
+                variablesReference: 0,
+            }));
         }
         this._sendResponse(req, { variables });
     }

--- a/src/debugCodeLens.js
+++ b/src/debugCodeLens.js
@@ -1,0 +1,99 @@
+'use strict';
+const vscode = require('vscode');
+
+/**
+ * CodeLens provider for MQL debug watch annotations.
+ *
+ * Shows an "Add @watch" lens on breakpoint lines that don't already have
+ * a nearby `@watch` annotation. Clicking inserts a `// @watch ` comment
+ * above the breakpoint line for the user to fill in.
+ */
+class DebugWatchCodeLensProvider {
+    constructor() {
+        this._onDidChangeCodeLenses = new vscode.EventEmitter();
+        this.onDidChangeCodeLenses = this._onDidChangeCodeLenses.event;
+
+        // Refresh when breakpoints change
+        this._bpDisposable = vscode.debug.onDidChangeBreakpoints(() => {
+            this._onDidChangeCodeLenses.fire();
+        });
+    }
+
+    dispose() {
+        this._bpDisposable.dispose();
+        this._onDidChangeCodeLenses.dispose();
+    }
+
+    /**
+     * @param {vscode.TextDocument} document
+     * @returns {vscode.CodeLens[]}
+     */
+    provideCodeLenses(document) {
+        const lenses = [];
+        const breakpoints = vscode.debug.breakpoints.filter(bp =>
+            bp instanceof vscode.SourceBreakpoint &&
+            bp.location.uri.fsPath === document.uri.fsPath &&
+            bp.enabled
+        );
+
+        for (const bp of breakpoints) {
+            const line = bp.location.range.start.line; // 0-based
+            if (this._hasWatchAnnotation(document, line)) continue;
+
+            const range = new vscode.Range(line, 0, line, 0);
+            lenses.push(new vscode.CodeLens(range, {
+                title: '$(eye) Add @watch annotation',
+                command: 'mql_tools.insertWatchAnnotation',
+                arguments: [document.uri, line],
+            }));
+        }
+        return lenses;
+    }
+
+    /**
+     * Check if there's already a @watch annotation within 5 lines above the breakpoint.
+     * @param {vscode.TextDocument} document
+     * @param {number} bpLine  0-based
+     * @returns {boolean}
+     */
+    _hasWatchAnnotation(document, bpLine) {
+        const from = Math.max(0, bpLine - 5);
+        for (let i = from; i <= bpLine; i++) {
+            if (document.lineAt(i).text.includes('@watch')) return true;
+        }
+        return false;
+    }
+}
+
+/**
+ * Insert a `// @watch ` annotation above the given line.
+ * @param {vscode.Uri} uri
+ * @param {number} line  0-based
+ */
+async function insertWatchAnnotation(uri, line) {
+    const editor = await vscode.window.showTextDocument(uri);
+    const indent = editor.document.lineAt(line).text.match(/^(\s*)/)[1];
+    const snippet = new vscode.SnippetString(`${indent}// @watch \${1:varName}\n`);
+    const position = new vscode.Position(line, 0);
+    await editor.insertSnippet(snippet, position);
+}
+
+/**
+ * Register the CodeLens provider and the insert command.
+ * @param {vscode.ExtensionContext} context
+ */
+function registerDebugCodeLens(context) {
+    const provider = new DebugWatchCodeLensProvider();
+    const selector = [
+        { language: 'mql5', scheme: 'file' },
+        { language: 'mql4', scheme: 'file' },
+        { language: 'cpp', pattern: '**/*.mqh', scheme: 'file' },
+    ];
+    context.subscriptions.push(
+        vscode.languages.registerCodeLensProvider(selector, provider),
+        vscode.commands.registerCommand('mql_tools.insertWatchAnnotation', insertWatchAnnotation),
+        provider,
+    );
+}
+
+module.exports = { registerDebugCodeLens, DebugWatchCodeLensProvider };

--- a/src/debugCodeLens.js
+++ b/src/debugCodeLens.js
@@ -58,7 +58,8 @@ class DebugWatchCodeLensProvider {
      */
     _hasWatchAnnotation(document, bpLine) {
         const from = Math.max(0, bpLine - 5);
-        for (let i = from; i <= bpLine; i++) {
+        const to = Math.min(document.lineCount - 1, bpLine + 2);
+        for (let i = from; i <= to; i++) {
             if (document.lineAt(i).text.includes('@watch')) return true;
         }
         return false;

--- a/src/debugInstrumentation.js
+++ b/src/debugInstrumentation.js
@@ -137,6 +137,119 @@ function isConditionSafe(condition) {
     return stack.length === 0 && !inQuote;
 }
 
+// -------------------------------------------------------------------------
+// Expression watch safety — function-call allowlist
+// -------------------------------------------------------------------------
+
+/**
+ * Read-only MQL5 built-in functions safe to call from expression watches.
+ * These have no side effects — they only read market data, account info, etc.
+ * Any function call NOT in this set is rejected to prevent code injection
+ * (e.g. a malicious `// @watch:int OrderSend(request, result)` hidden in shared code).
+ */
+const SAFE_READONLY_FUNCTIONS = new Set([
+    // Market data
+    'SymbolInfoDouble', 'SymbolInfoInteger', 'SymbolInfoString',
+    'SymbolInfoTick', 'SymbolInfoSessionQuote', 'SymbolInfoSessionTrade',
+    'MarketBookGet', 'SymbolsTotal', 'SymbolName', 'SymbolSelect',
+    'SymbolIsSynchronized', 'iOpen', 'iClose', 'iHigh', 'iLow',
+    'iVolume', 'iTime', 'iSpread', 'iTickVolume', 'iBars',
+    'iBarShift', 'iHighest', 'iLowest',
+    // Series / timeseries
+    'SeriesInfoInteger', 'Bars', 'BarsCalculated',
+    'CopyRates', 'CopyTime', 'CopyOpen', 'CopyHigh', 'CopyLow',
+    'CopyClose', 'CopyTickVolume', 'CopyRealVolume', 'CopySpread',
+    'CopyTicks', 'CopyTicksRange',
+    // Account info
+    'AccountInfoDouble', 'AccountInfoInteger', 'AccountInfoString',
+    // Position / order / deal queries (read-only)
+    'PositionsTotal', 'PositionGetSymbol', 'PositionSelect',
+    'PositionGetDouble', 'PositionGetInteger', 'PositionGetString',
+    'PositionGetTicket', 'PositionSelectByTicket',
+    'OrdersTotal', 'OrderGetTicket', 'OrderSelect',
+    'OrderGetDouble', 'OrderGetInteger', 'OrderGetString',
+    'HistoryOrdersTotal', 'HistoryOrderSelect', 'HistoryOrderGetTicket',
+    'HistoryOrderGetDouble', 'HistoryOrderGetInteger', 'HistoryOrderGetString',
+    'HistoryDealsTotal', 'HistoryDealSelect', 'HistoryDealGetTicket',
+    'HistoryDealGetDouble', 'HistoryDealGetInteger', 'HistoryDealGetString',
+    'HistorySelect', 'HistorySelectByPosition',
+    // Math
+    'MathAbs', 'MathCeil', 'MathFloor', 'MathRound', 'MathMax', 'MathMin',
+    'MathMod', 'MathPow', 'MathSqrt', 'MathLog', 'MathLog10', 'MathExp',
+    'MathSin', 'MathCos', 'MathTan', 'MathArcsin', 'MathArccos', 'MathArctan',
+    'MathIsValidNumber', 'MathRand', 'MathSrand',
+    'fabs', 'ceil', 'floor', 'round', 'fmax', 'fmin', 'fmod', 'pow', 'sqrt',
+    'log', 'log10', 'exp', 'sin', 'cos', 'tan', 'asin', 'acos', 'atan',
+    // String (read-only)
+    'StringLen', 'StringFind', 'StringSubstr', 'StringGetCharacter',
+    'StringCompare', 'StringConcatenate', 'StringFormat',
+    'IntegerToString', 'DoubleToString', 'TimeToString',
+    'CharToString', 'ShortToString', 'EnumToString',
+    'StringToInteger', 'StringToDouble', 'StringToTime',
+    // Array info (read-only)
+    'ArraySize', 'ArrayRange', 'ArrayMaximum', 'ArrayMinimum',
+    'ArrayBsearch', 'ArrayIsDynamic', 'ArrayIsSeries',
+    // Object info (read-only)
+    'ObjectFind', 'ObjectGetDouble', 'ObjectGetInteger', 'ObjectGetString',
+    'ObjectsTotal', 'ObjectName', 'ObjectGetTimeByValue', 'ObjectGetValueByTime',
+    // Chart info (read-only)
+    'ChartID', 'ChartSymbol', 'ChartPeriod',
+    'ChartGetDouble', 'ChartGetInteger', 'ChartGetString',
+    // Time
+    'TimeCurrent', 'TimeLocal', 'TimeGMT', 'TimeTradeServer',
+    'TimeToStruct', 'StructToTime', 'TimeGMTOffset', 'TimeDaylightSavings',
+    // Terminal info
+    'TerminalInfoInteger', 'TerminalInfoDouble', 'TerminalInfoString',
+    'MQLInfoInteger', 'MQLInfoString',
+    // Period / symbol
+    'Period', 'Symbol', 'Point', 'Digits',
+    // Type checking / conversion
+    'typename', 'sizeof', 'StringToCharArray',
+    // Indicator values
+    'iMA', 'iRSI', 'iMACD', 'iStochastic', 'iBands', 'iATR',
+    'iCCI', 'iADX', 'iSAR', 'iOBV', 'iMFI', 'iAD',
+    'iCustom', 'CopyBuffer',
+    // Normalization
+    'NormalizeDouble', 'SymbolInfoDouble',
+]);
+
+/**
+ * Validate that an expression is safe for use in an expression watch.
+ *
+ * Rules:
+ * - Balanced delimiters (delegated to isConditionSafe)
+ * - Any function call (identifier immediately followed by `(`) must be in
+ *   SAFE_READONLY_FUNCTIONS. This blocks side-effecting calls like OrderSend,
+ *   FileDelete, WebRequest, etc.
+ * - Semicolons are forbidden (prevents statement injection)
+ * - Preprocessor directives are forbidden
+ *
+ * @param {string} expr  The expression text
+ * @returns {{ safe: boolean, reason?: string }}
+ */
+function isExpressionSafe(expr) {
+    if (!expr || !expr.trim()) return { safe: false, reason: 'empty expression' };
+    if (!isConditionSafe(expr)) return { safe: false, reason: 'unbalanced delimiters' };
+    if (expr.includes(';')) return { safe: false, reason: 'semicolons not allowed' };
+    if (expr.trimStart().startsWith('#')) return { safe: false, reason: 'preprocessor directives not allowed' };
+
+    // Find all function calls: identifier followed by (
+    const RE_FUNC_CALL = /\b([a-zA-Z_]\w*)\s*\(/g;
+    let m;
+    while ((m = RE_FUNC_CALL.exec(expr)) !== null) {
+        const funcName = m[1];
+        // Skip MQL type casts that look like function calls: int(x), double(x), etc.
+        if (/^(int|uint|short|ushort|char|uchar|long|ulong|double|float|string|bool|datetime|color)$/.test(funcName)) {
+            continue;
+        }
+        if (!SAFE_READONLY_FUNCTIONS.has(funcName)) {
+            return { safe: false, reason: `function '${funcName}' is not in the allowed read-only list` };
+        }
+    }
+
+    return { safe: true };
+}
+
 /**
  * Check if a file is a "user file" (not a system include from MQL5/Include/).
  * User files get full probe instrumentation at every executable line.
@@ -280,30 +393,68 @@ function findInjectionPoint(lines, targetLine) {
 }
 
 /**
- * Parse `// @watch varName [varName2 ...]` annotations from lines around the breakpoint.
+ * Parse `// @watch varName [varName2 ...]` and `// @watch:type expression` annotations.
  * Searches up to 5 lines before and 2 lines after the breakpoint line.
- * Supports multiple variable names on a single annotation line.
+ *
+ * Simple form:    `// @watch x y z`        → variable names (type resolved later)
+ * Typed form:     `// @watch:double expr`  → expression, validated against allowlist
+ * Unsafe form:    `// @watch!:double expr` → expression, bypasses safety checks
+ *
+ * The `!` modifier explicitly opts into unrestricted expression injection.
+ * Without it, any function calls in the expression must be in SAFE_READONLY_FUNCTIONS.
  *
  * @param {string[]} lines
  * @param {number}   bpLine  1-based breakpoint line
- * @returns {string[]}  Variable names to watch
+ * @returns {{ names: string[], expressions: { expr: string, type: string, label: string }[], rejected: { expr: string, reason: string, line: number }[] }}
  */
 function parseWatchAnnotations(lines, bpLine) {
-    const RE_WATCH = /\/\/\s*@watch\s+([\w\s]+)/;
-    const vars = [];
+    const RE_WATCH_SIMPLE = /\/\/\s*@watch\s+([\w\s]+)/;
+    const RE_WATCH_TYPED = /\/\/\s*@watch(!?):(\w+)\s+(.+)/;
+    const names = [];
+    const expressions = [];
+    const rejected = [];
     const from = Math.max(0, bpLine - 6);
     const to = Math.min(lines.length - 1, bpLine + 1);
 
     for (let i = from; i <= to; i++) {
-        const m = lines[i].match(RE_WATCH);
+        // Try typed expression form first (more specific)
+        const tm = lines[i].match(RE_WATCH_TYPED);
+        if (tm) {
+            const unsafe = tm[1] === '!';
+            const type = tm[2].trim();
+            const expr = tm[3].trim();
+            if (expr) {
+                if (unsafe) {
+                    // @watch!: — user explicitly opted into unrestricted mode
+                    if (!isConditionSafe(expr)) {
+                        rejected.push({ expr, reason: 'unbalanced delimiters', line: i + 1 });
+                    } else {
+                        const label = expr.length > 40 ? expr.substring(0, 37) + '...' : expr;
+                        expressions.push({ expr, type, label });
+                    }
+                } else {
+                    // @watch: — validated against allowlist
+                    const check = isExpressionSafe(expr);
+                    if (check.safe) {
+                        const label = expr.length > 40 ? expr.substring(0, 37) + '...' : expr;
+                        expressions.push({ expr, type, label });
+                    } else {
+                        rejected.push({ expr, reason: check.reason, line: i + 1 });
+                    }
+                }
+            }
+            continue;
+        }
+        // Simple variable name form
+        const m = lines[i].match(RE_WATCH_SIMPLE);
         if (m) {
-            const names = m[1].trim().split(/\s+/);
-            for (const n of names) {
-                if (n && !vars.includes(n)) vars.push(n);
+            const parsed = m[1].trim().split(/\s+/);
+            for (const n of parsed) {
+                if (n && !names.includes(n)) names.push(n);
             }
         }
     }
-    return vars;
+    return { names, expressions, rejected };
 }
 
 // -------------------------------------------------------------------------
@@ -351,15 +502,22 @@ const MQL_ARRAY_MACROS = {
  * Falls back to MQL_DBG_WATCH (double) for unknown types.
  * @param {string} mqlType
  * @param {boolean} [isArray=false]
+ * @param {boolean} [batch=false]  Use batch-mode macros (MQL_DBG_BWATCH_*)
  */
-function macroForType(mqlType, isArray) {
-    if (!mqlType) return 'MQL_DBG_WATCH';
+function macroForType(mqlType, isArray, batch) {
+    if (!mqlType) return batch ? 'MQL_DBG_BWATCH' : 'MQL_DBG_WATCH';
     const key = mqlType.replace(/\b(const|static|input)\b/g, '').trim().toLowerCase();
+    let macro;
     if (isArray) {
-        return MQL_ARRAY_MACROS[key] || null; // null = skip unsupported array type
+        macro = MQL_ARRAY_MACROS[key] || null;
+        if (!macro) return null; // null = skip unsupported array type
+    } else if (key.startsWith('enum_')) {
+        macro = 'MQL_DBG_WATCH_INT';
+    } else {
+        macro = MQL_TYPE_MACROS[key] || 'MQL_DBG_WATCH';
     }
-    if (key.startsWith('enum_')) return 'MQL_DBG_WATCH_INT';
-    return MQL_TYPE_MACROS[key] || 'MQL_DBG_WATCH';
+    // Batch mode: MQL_DBG_WATCH_* → MQL_DBG_BWATCH_*
+    return batch ? macro.replace('MQL_DBG_WATCH', 'MQL_DBG_BWATCH') : macro;
 }
 
 // -------------------------------------------------------------------------
@@ -1342,14 +1500,19 @@ function buildLogExpression(template, watchVars) {
  * @returns {string[]}  Lines to insert
  */
 function buildProbeInjection(probeId, label, watchVars, condition, logMessage) {
+    // Use batch-mode macros to reduce file I/O (single write+flush per probe)
     const watchLines = [];
-    watchLines.push(`MQL_DBG_BREAK("${label}");`);
+    watchLines.push(`MQL_DBG_BBREAK("${label}");`);
     for (const v of watchVars) {
-        if (v.isArray) {
-            const arrMacro = macroForType(v.type, true);
+        if (v.isExpression) {
+            // Expression watch: inject the expression verbatim as the value
+            const macro = macroForType(v.type, false, true);
+            watchLines.push(`${macro}("${v.name}", ${v.expr});`);
+        } else if (v.isArray) {
+            const arrMacro = macroForType(v.type, true, true);
             if (arrMacro) watchLines.push(`${arrMacro}("${v.name}", ${v.name});`);
         } else {
-            const macro = macroForType(v.type);
+            const macro = macroForType(v.type, false, true);
             watchLines.push(`${macro}("${v.name}", ${v.name});`);
         }
     }
@@ -1364,24 +1527,25 @@ function buildProbeInjection(probeId, label, watchVars, condition, logMessage) {
 
     const hasLogMessage = logMessage && logMessage.trim();
     if (hasLogMessage) {
-        // Compile-time logpoint message available: use MQL_DBG_LOG in logpoint path
         const logExpr = buildLogExpression(logMessage, watchVars);
         result.push(
             `if (MqlDebugProbeCheck(${probeId})${condExpr}) {`,
             `  if (MqlDebugIsLogpoint(${probeId})) {`,
             `    MQL_DBG_LOG(${logExpr});`,
             '  } else {',
+            '    MqlDebugBatchStart();',
             ...watchLines.map(l => `    ${l}`),
+            '    MqlDebugBatchFlush();',
             '    MQL_DBG_PAUSE;',
             '  }',
             '}'
         );
     } else {
-        // No logpoint message: emit BREAK + watches always, only PAUSE when not a logpoint.
-        // This allows logpoints added mid-session to work without recompilation.
         result.push(
             `if (MqlDebugProbeCheck(${probeId})${condExpr}) {`,
+            '  MqlDebugBatchStart();',
             ...watchLines.map(l => `  ${l}`),
+            '  MqlDebugBatchFlush();',
             `  if (!MqlDebugIsLogpoint(${probeId})) MQL_DBG_PAUSE;`,
             '}'
         );
@@ -1520,6 +1684,143 @@ function resolveIncludePath(incPath, includeBase, mql5Root) {
     return null;
 }
 
+// -------------------------------------------------------------------------
+// Heuristic scoring & context-aware variable detection
+// -------------------------------------------------------------------------
+
+/**
+ * Score a variable's relevance to a breakpoint based on proximity and usage.
+ * Higher scores = more interesting to the user.
+ *
+ * @param {string[]} lines   Source lines (0-based array)
+ * @param {number}   bpLine  1-based breakpoint line
+ * @param {string}   varName Variable name to score
+ * @returns {number}
+ */
+function scoreVariableRelevance(lines, bpLine, varName) {
+    const idx = bpLine - 1;
+    const escaped = varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const reWord = new RegExp('\\b' + escaped + '\\b');
+    // Assignment: varName = ... or varName += ... etc. (but not == or !=)
+    const reAssign = new RegExp('\\b' + escaped + '\\s*(?:[+\\-*/%&|^]|<<|>>)?=(?!=)');
+
+    let score = 0;
+
+    // Check assignment proximity (most valuable signal)
+    for (let dist = 0; dist <= 5; dist++) {
+        const lineIdx = idx - dist;
+        if (lineIdx < 0) break;
+        const line = lines[lineIdx];
+        if (reAssign.test(line)) {
+            score += dist === 0 ? 10 : dist <= 3 ? 8 : 5;
+            break;
+        }
+    }
+
+    // Count usage frequency within ±10 lines
+    const from = Math.max(0, idx - 10);
+    const to = Math.min(lines.length - 1, idx + 3);
+    let refs = 0;
+    for (let i = from; i <= to; i++) {
+        const trimmed = lines[i].trimStart();
+        if (trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('#')) continue;
+        if (reWord.test(lines[i])) refs++;
+    }
+    score += Math.min(refs, 5); // cap frequency bonus at 5
+
+    return score;
+}
+
+/**
+ * Find variables used in the enclosing control-flow condition (if/for/while/switch).
+ * Walks backward from the breakpoint to find the nearest enclosing control structure.
+ *
+ * @param {string[]} lines   Source lines (0-based array)
+ * @param {number}   bpLine  1-based breakpoint line
+ * @returns {string[]}  Variable identifiers from the condition expression
+ */
+function findEnclosingControlFlowVars(lines, bpLine) {
+    const idx = bpLine - 1;
+    if (idx < 0 || idx >= lines.length) return [];
+
+    // Walk backward tracking brace depth (using braceDepthDelta for string/comment safety)
+    let braceDepth = 0;
+    for (let i = idx; i >= 0; i--) {
+        const r = braceDepthDelta(lines[i]);
+        // Walking backward: subtract delta (same pattern as parseLocalsInScope)
+        braceDepth -= r.delta;
+
+        // At depth < 0, we've exited BP's block — check the line with `{` for a control keyword
+        if (braceDepth < 0) {
+            // The control keyword might be on this line or previous lines (multi-line condition)
+            let condText = '';
+            for (let j = Math.max(0, i - 5); j <= i; j++) {
+                condText += ' ' + lines[j];
+            }
+            const m = condText.match(/\b(?:if|for|while|switch)\s*\(([^)]*(?:\([^)]*\))*[^)]*)\)/);
+            if (!m) return [];
+
+            const condExpr = m[1];
+            const vars = [];
+            const RE_IDENT = /\b([a-zA-Z_]\w*)\b/g;
+            let rm;
+            while ((rm = RE_IDENT.exec(condExpr)) !== null) {
+                const name = rm[1];
+                if (!NON_VARNAME_KEYWORDS.has(name) && !NON_TYPE_KEYWORDS.has(name) &&
+                    !vars.includes(name) && !/^\d/.test(name)) {
+                    vars.push(name);
+                }
+            }
+            return vars;
+        }
+    }
+    return [];
+}
+
+/**
+ * Find variables passed as arguments to function calls on or near the breakpoint line.
+ *
+ * @param {string[]} lines   Source lines (0-based array)
+ * @param {number}   bpLine  1-based breakpoint line
+ * @returns {string[]}  Variable identifiers used as function arguments
+ */
+function findFunctionCallArgs(lines, bpLine) {
+    const idx = bpLine - 1;
+    if (idx < 0 || idx >= lines.length) return [];
+
+    const vars = [];
+    const from = Math.max(0, idx - 1);
+    const to = Math.min(lines.length - 1, idx + 1);
+
+    for (let i = from; i <= to; i++) {
+        const trimmed = lines[i].trimStart();
+        if (trimmed.startsWith('//') || trimmed.startsWith('#')) continue;
+
+        // Match function calls: FuncName(args...)
+        const RE_CALL = /\b[a-zA-Z_]\w*\s*\(([^)]*)\)/g;
+        let cm;
+        while ((cm = RE_CALL.exec(lines[i])) !== null) {
+            const argStr = cm[1];
+            if (!argStr.trim()) continue;
+            // Extract identifiers from argument list (skip string literals)
+            const RE_ARG_IDENT = /\b([a-zA-Z_]\w*)\b/g;
+            let am;
+            while ((am = RE_ARG_IDENT.exec(argStr)) !== null) {
+                const name = am[1];
+                if (!NON_VARNAME_KEYWORDS.has(name) && !NON_TYPE_KEYWORDS.has(name) &&
+                    !vars.includes(name) && !/^\d/.test(name)) {
+                    // Skip if it looks like a function call itself (next non-space char is '(')
+                    const afterIdx = am.index + am[0].length;
+                    const rest = argStr.substring(afterIdx).trimStart();
+                    if (rest.startsWith('(')) continue;
+                    vars.push(name);
+                }
+            }
+        }
+    }
+    return vars;
+}
+
 /**
  * Collect all watch variables for a breakpoint at the given line.
  * Factored out so it can be called from the all-line probe loop.
@@ -1531,11 +1832,30 @@ function resolveIncludePath(incPath, includeBase, mql5Root) {
  * @returns {{ name: string, type: string, isArray?: boolean }[]}
  */
 function collectWatchVars(lines, bpLine, typeDB, deepAnalysis) {
-    const annotatedVars = parseWatchAnnotations(lines, bpLine);
+    const annotations = parseWatchAnnotations(lines, bpLine);
+    const annotatedVars = annotations.names;
     const localVars = parseLocalsInScope(lines, bpLine);
+
+    // Warn about rejected expression watches (unsafe function calls, etc.)
+    for (const rej of annotations.rejected) {
+        const msg = `⚠ Expression watch rejected at line ${rej.line}: "${rej.expr}" — ${rej.reason}`;
+        if (vscode && vscode.window) {
+            vscode.window.showWarningMessage(msg);
+        }
+    }
 
     const seen = new Set();
     const watchVars = [];
+
+    // Expression watches: injected verbatim with explicit type
+    for (const ew of annotations.expressions) {
+        const key = `__expr__${ew.expr}`;
+        if (!seen.has(key)) {
+            seen.add(key);
+            watchVars.push({ name: ew.label, type: ew.type, isExpression: true, expr: ew.expr });
+        }
+    }
+
     for (const name of annotatedVars) {
         seen.add(name);
         const local = localVars.find(l => l.name === name);
@@ -1545,6 +1865,38 @@ function collectWatchVars(lines, bpLine, typeDB, deepAnalysis) {
         if (!seen.has(local.name)) {
             seen.add(local.name);
             watchVars.push(local);
+        }
+    }
+
+    // Add variables from enclosing control-flow conditions (if/for/while/switch)
+    for (const cfName of findEnclosingControlFlowVars(lines, bpLine)) {
+        if (seen.has(cfName)) continue;
+        const local = localVars.find(l => l.name === cfName);
+        if (local) {
+            seen.add(cfName);
+            watchVars.push({ name: cfName, type: local.type, isArray: local.isArray });
+        } else if (typeDB.globalMap.has(cfName)) {
+            const g = typeDB.globalMap.get(cfName);
+            if (isWatchableType(g.type, typeDB.classMap)) {
+                seen.add(cfName);
+                watchVars.push({ name: cfName, type: g.type, isArray: g.isArray });
+            }
+        }
+    }
+
+    // Add variables used as function call arguments near BP
+    for (const argName of findFunctionCallArgs(lines, bpLine)) {
+        if (seen.has(argName)) continue;
+        const local = localVars.find(l => l.name === argName);
+        if (local) {
+            seen.add(argName);
+            watchVars.push({ name: argName, type: local.type, isArray: local.isArray });
+        } else if (typeDB.globalMap.has(argName)) {
+            const g = typeDB.globalMap.get(argName);
+            if (isWatchableType(g.type, typeDB.classMap)) {
+                seen.add(argName);
+                watchVars.push({ name: argName, type: g.type, isArray: g.isArray });
+            }
         }
     }
 
@@ -1562,6 +1914,24 @@ function collectWatchVars(lines, bpLine, typeDB, deepAnalysis) {
         if (!seen.has(member.name)) {
             seen.add(member.name);
             watchVars.push(member);
+        }
+    }
+
+    // Auto-expand small struct/class locals (<=8 watchable fields) at default level.
+    // Deep analysis does full uncapped expansion below.
+    if (!deepAnalysis) {
+        const MAX_AUTO_EXPAND_FIELDS = 8;
+        for (const local of localVars) {
+            if (!typeDB.classMap.has(local.type)) continue;
+            // Count watchable fields for this type (walk inheritance)
+            const fields = findClassFieldExpansions([local], typeDB.classMap);
+            if (fields.length === 0 || fields.length > MAX_AUTO_EXPAND_FIELDS) continue;
+            for (const field of fields) {
+                if (!seen.has(field.name)) {
+                    seen.add(field.name);
+                    watchVars.push(field);
+                }
+            }
         }
     }
 
@@ -1610,6 +1980,21 @@ function collectWatchVars(lines, bpLine, typeDB, deepAnalysis) {
         seen.add(expr);
         watchVars.push({ name: expr, type, isArray });
     }
+
+    // Sort by relevance: annotated/expression vars stay at top, rest sorted by precomputed score
+    const annotatedSet = new Set(annotatedVars);
+    const scoreCache = new Map();
+    for (const v of watchVars) {
+        if (!annotatedSet.has(v.name) && !v.isExpression) {
+            scoreCache.set(v.name, scoreVariableRelevance(lines, bpLine, v.name));
+        }
+    }
+    watchVars.sort((a, b) => {
+        const aPinned = (annotatedSet.has(a.name) || a.isExpression) ? 1 : 0;
+        const bPinned = (annotatedSet.has(b.name) || b.isExpression) ? 1 : 0;
+        if (aPinned !== bPinned) return bPinned - aPinned; // pinned first
+        return (scoreCache.get(b.name) || 0) - (scoreCache.get(a.name) || 0);
+    });
 
     return watchVars;
 }
@@ -1994,6 +2379,8 @@ module.exports = {
     _test: {
         MqlLineClassifier,
         isConditionSafe,
+        isExpressionSafe,
+        SAFE_READONLY_FUNCTIONS,
         findInjectionPoint,
         parseWatchAnnotations,
         macroForType,
@@ -2004,5 +2391,9 @@ module.exports = {
         braceDepthDelta,
         buildLogExpression,
         buildProbeInjection,
+        scoreVariableRelevance,
+        findEnclosingControlFlowVars,
+        findFunctionCallArgs,
+        collectWatchVars,
     }
 };

--- a/src/debugInstrumentation.js
+++ b/src/debugInstrumentation.js
@@ -1506,8 +1506,10 @@ function buildProbeInjection(probeId, label, watchVars, condition, logMessage) {
     for (const v of watchVars) {
         if (v.isExpression) {
             // Expression watch: inject the expression verbatim as the value
+            // Escape the label for safe embedding in an MQL string literal
+            const safeLabel = v.name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
             const macro = macroForType(v.type, false, true);
-            watchLines.push(`${macro}("${v.name}", ${v.expr});`);
+            watchLines.push(`${macro}("${safeLabel}", ${v.expr});`);
         } else if (v.isArray) {
             const arrMacro = macroForType(v.type, true, true);
             if (arrMacro) watchLines.push(`${arrMacro}("${v.name}", ${v.name});`);
@@ -1796,11 +1798,21 @@ function findFunctionCallArgs(lines, bpLine) {
         const trimmed = lines[i].trimStart();
         if (trimmed.startsWith('//') || trimmed.startsWith('#')) continue;
 
-        // Match function calls: FuncName(args...)
-        const RE_CALL = /\b[a-zA-Z_]\w*\s*\(([^)]*)\)/g;
+        // Find function calls by locating "Identifier(" then walking to the balanced ")"
+        const RE_CALL_START = /\b[a-zA-Z_]\w*\s*\(/g;
         let cm;
-        while ((cm = RE_CALL.exec(lines[i])) !== null) {
-            const argStr = cm[1];
+        const line = lines[i];
+        while ((cm = RE_CALL_START.exec(line)) !== null) {
+            // Walk from the '(' to find the matching ')' respecting nesting
+            const openIdx = cm.index + cm[0].length - 1; // index of '('
+            let depth = 1;
+            let endIdx = -1;
+            for (let c = openIdx + 1; c < line.length && depth > 0; c++) {
+                if (line[c] === '(') depth++;
+                else if (line[c] === ')') { depth--; if (depth === 0) { endIdx = c; } }
+            }
+            if (endIdx === -1) continue; // unbalanced — skip
+            const argStr = line.substring(openIdx + 1, endIdx);
             if (!argStr.trim()) continue;
             // Extract identifiers from argument list (skip string literals)
             const RE_ARG_IDENT = /\b([a-zA-Z_]\w*)\b/g;

--- a/src/debugInstrumentation.js
+++ b/src/debugInstrumentation.js
@@ -151,7 +151,8 @@ const SAFE_READONLY_FUNCTIONS = new Set([
     // Market data
     'SymbolInfoDouble', 'SymbolInfoInteger', 'SymbolInfoString',
     'SymbolInfoTick', 'SymbolInfoSessionQuote', 'SymbolInfoSessionTrade',
-    'MarketBookGet', 'SymbolsTotal', 'SymbolName', 'SymbolSelect',
+    'MarketBookGet', 'SymbolsTotal', 'SymbolName',
+    // Note: SymbolSelect is excluded — SymbolSelect(sym, true) mutates Market Watch
     'SymbolIsSynchronized', 'iOpen', 'iClose', 'iHigh', 'iLow',
     'iVolume', 'iTime', 'iSpread', 'iTickVolume', 'iBars',
     'iBarShift', 'iHighest', 'iLowest',

--- a/src/debugInstrumentation.js
+++ b/src/debugInstrumentation.js
@@ -211,7 +211,7 @@ const SAFE_READONLY_FUNCTIONS = new Set([
     'iCCI', 'iADX', 'iSAR', 'iOBV', 'iMFI', 'iAD',
     'iCustom', 'CopyBuffer',
     // Normalization
-    'NormalizeDouble', 'SymbolInfoDouble',
+    'NormalizeDouble',
 ]);
 
 /**

--- a/src/debugStateStore.js
+++ b/src/debugStateStore.js
@@ -192,14 +192,17 @@ class DebugStateStore {
 
     /**
      * Get the value history of a variable across recent breakpoint hits.
+     * When bpLabel is provided, only returns entries from that specific breakpoint.
      * @param {string} varName
      * @param {number} [maxEntries=20]
+     * @param {string} [bpLabel]  Breakpoint label to scope the history to
      * @returns {{ value: string, timestamp: string, hitCount: number, label: string }[]}
      */
-    getVariableHistory(varName, maxEntries = 20) {
+    getVariableHistory(varName, maxEntries = 20, bpLabel) {
         const history = [];
         for (let i = this.hits.length - 1; i >= 0 && history.length < maxEntries; i--) {
             const hit = this.hits[i];
+            if (bpLabel && hit.label !== bpLabel) continue;
             const w = hit.watches.find(w => w.varName === varName);
             if (w) {
                 history.push({

--- a/src/debugStateStore.js
+++ b/src/debugStateStore.js
@@ -55,6 +55,8 @@ class DebugStateStore {
         this.totalHitCount = 0;
         this.totalLogCount = 0;
         this.sessionActive = false;
+        /** Watch values from the previous breakpoint hit, for change detection */
+        this._previousHitWatches = new Map(); // varName -> value (string)
     }
 
     // -------------------------------------------------------------------------
@@ -97,6 +99,14 @@ class DebugStateStore {
     _applyOne(event) {
         switch (event.type) {
             case 'break': {
+                // Snapshot current hit's watches for value-change detection
+                const prevHit = this.latestHit;
+                this._previousHitWatches = new Map();
+                if (prevHit && prevHit.watches) {
+                    for (const w of prevHit.watches) {
+                        this._previousHitWatches.set(w.varName, String(w.value));
+                    }
+                }
                 const count = (this.hitCounts.get(event.label) || 0) + 1;
                 this.hitCounts.set(event.label, count);
                 const hit = {
@@ -178,6 +188,29 @@ class DebugStateStore {
     /** @returns {WatchEntry[]} All latest watch values as an array */
     get latestWatchList() {
         return Array.from(this.latestWatches.values());
+    }
+
+    /**
+     * Get the value history of a variable across recent breakpoint hits.
+     * @param {string} varName
+     * @param {number} [maxEntries=20]
+     * @returns {{ value: string, timestamp: string, hitCount: number, label: string }[]}
+     */
+    getVariableHistory(varName, maxEntries = 20) {
+        const history = [];
+        for (let i = this.hits.length - 1; i >= 0 && history.length < maxEntries; i--) {
+            const hit = this.hits[i];
+            const w = hit.watches.find(w => w.varName === varName);
+            if (w) {
+                history.push({
+                    value: String(w.value),
+                    timestamp: hit.timestamp,
+                    hitCount: hit.hitCount,
+                    label: hit.label,
+                });
+            }
+        }
+        return history.reverse(); // chronological order
     }
 
     // -------------------------------------------------------------------------

--- a/src/extension.js
+++ b/src/extension.js
@@ -67,6 +67,7 @@ const {
 } = require('./debugBridge');
 const { MqlDebugAdapter } = require('./debugAdapter');
 const { store: debugStore } = require('./debugStateStore');
+const { registerDebugCodeLens } = require('./debugCodeLens');
 const { showStartupPage } = require('./startupPage');
 
 
@@ -2401,6 +2402,9 @@ function activate(context) {
     // Show Startup Page PoC
     showStartupPage(context);
 
+
+    // Debug watch annotation CodeLens
+    registerDebugCodeLens(context);
 
     // Clear symbol cache when a document is closed
     context.subscriptions.push(vscode.workspace.onDidCloseTextDocument((document) => {

--- a/test/debugFeatures.test.js
+++ b/test/debugFeatures.test.js
@@ -335,3 +335,84 @@ suite('MqlDebugBridge — writeBreakpointConfig extended format', function () {
         assert.strictEqual(readConfig(), '5hS7');
     });
 });
+
+// ---------------------------------------------------------------------------
+// DebugStateStore — previous hit watches & variable history
+// ---------------------------------------------------------------------------
+
+suite('DebugStateStore — value change tracking', function () {
+    let s;
+    setup(function () { s = new DebugStateStore(); });
+
+    test('_previousHitWatches is empty on first hit', function () {
+        s.startSession();
+        s.applyBatch([
+            { type: 'break', label: 'bp1', file: 'a.mq5', func: 'F', line: 10, timestamp: 't1' },
+            { type: 'watch', varName: 'x', varType: 'int', value: '5', file: 'a.mq5', func: 'F', line: 10, timestamp: 't1' },
+        ]);
+        assert.strictEqual(s._previousHitWatches.size, 0, 'no previous watches on first hit');
+    });
+
+    test('_previousHitWatches captures values from previous hit', function () {
+        s.startSession();
+        s.applyBatch([
+            { type: 'break', label: 'bp1', file: 'a.mq5', func: 'F', line: 10, timestamp: 't1' },
+            { type: 'watch', varName: 'x', varType: 'int', value: '5', file: 'a.mq5', func: 'F', line: 10, timestamp: 't1' },
+        ]);
+        s.applyBatch([
+            { type: 'break', label: 'bp1', file: 'a.mq5', func: 'F', line: 10, timestamp: 't2' },
+            { type: 'watch', varName: 'x', varType: 'int', value: '10', file: 'a.mq5', func: 'F', line: 10, timestamp: 't2' },
+        ]);
+        assert.strictEqual(s._previousHitWatches.get('x'), '5', 'should have previous value');
+    });
+
+    test('_previousHitWatches resets on session start', function () {
+        s.startSession();
+        s.applyBatch([
+            { type: 'break', label: 'bp1', file: 'a.mq5', func: 'F', line: 10, timestamp: 't1' },
+            { type: 'watch', varName: 'x', varType: 'int', value: '5', file: 'a.mq5', func: 'F', line: 10, timestamp: 't1' },
+        ]);
+        s.startSession(); // reset
+        assert.strictEqual(s._previousHitWatches.size, 0);
+    });
+});
+
+suite('DebugStateStore — getVariableHistory', function () {
+    let s;
+    setup(function () { s = new DebugStateStore(); });
+
+    test('returns empty for unknown variable', function () {
+        s.startSession();
+        const h = s.getVariableHistory('nonexistent');
+        assert.deepStrictEqual(h, []);
+    });
+
+    test('returns chronological value history', function () {
+        s.startSession();
+        for (let i = 1; i <= 3; i++) {
+            s.applyBatch([
+                { type: 'break', label: 'bp1', file: 'a.mq5', func: 'F', line: 10, timestamp: `t${i}` },
+                { type: 'watch', varName: 'x', varType: 'int', value: String(i * 10), file: 'a.mq5', func: 'F', line: 10, timestamp: `t${i}` },
+            ]);
+        }
+        const h = s.getVariableHistory('x');
+        assert.strictEqual(h.length, 3);
+        assert.strictEqual(h[0].value, '10');
+        assert.strictEqual(h[1].value, '20');
+        assert.strictEqual(h[2].value, '30');
+    });
+
+    test('respects maxEntries limit', function () {
+        s.startSession();
+        for (let i = 0; i < 25; i++) {
+            s.applyBatch([
+                { type: 'break', label: 'bp1', file: 'a.mq5', func: 'F', line: 10, timestamp: `t${i}` },
+                { type: 'watch', varName: 'x', varType: 'int', value: String(i), file: 'a.mq5', func: 'F', line: 10, timestamp: `t${i}` },
+            ]);
+        }
+        const h = s.getVariableHistory('x', 5);
+        assert.strictEqual(h.length, 5);
+        // Should be the LAST 5 entries (most recent)
+        assert.strictEqual(h[4].value, '24');
+    });
+});

--- a/test/debugFeatures.test.js
+++ b/test/debugFeatures.test.js
@@ -415,4 +415,29 @@ suite('DebugStateStore — getVariableHistory', function () {
         // Should be the LAST 5 entries (most recent)
         assert.strictEqual(h[4].value, '24');
     });
+
+    test('filters by breakpoint label when provided', function () {
+        s.startSession();
+        // Two different breakpoints, both watching 'x'
+        s.applyBatch([
+            { type: 'break', label: 'bp_A', file: 'a.mq5', func: 'F', line: 10, timestamp: 't1' },
+            { type: 'watch', varName: 'x', varType: 'int', value: '100', file: 'a.mq5', func: 'F', line: 10, timestamp: 't1' },
+        ]);
+        s.applyBatch([
+            { type: 'break', label: 'bp_B', file: 'a.mq5', func: 'G', line: 20, timestamp: 't2' },
+            { type: 'watch', varName: 'x', varType: 'int', value: '200', file: 'a.mq5', func: 'G', line: 20, timestamp: 't2' },
+        ]);
+        s.applyBatch([
+            { type: 'break', label: 'bp_A', file: 'a.mq5', func: 'F', line: 10, timestamp: 't3' },
+            { type: 'watch', varName: 'x', varType: 'int', value: '300', file: 'a.mq5', func: 'F', line: 10, timestamp: 't3' },
+        ]);
+        // Without label — returns all 3 hits
+        const all = s.getVariableHistory('x');
+        assert.strictEqual(all.length, 3);
+        // With label — returns only bp_A hits
+        const filtered = s.getVariableHistory('x', 20, 'bp_A');
+        assert.strictEqual(filtered.length, 2);
+        assert.strictEqual(filtered[0].value, '100');
+        assert.strictEqual(filtered[1].value, '300');
+    });
 });

--- a/test/debugInstrumentation.test.js
+++ b/test/debugInstrumentation.test.js
@@ -937,6 +937,18 @@ suite('debugInstrumentation', function () {
             assert.ok(vars.includes('text'), 'should find text');
         });
 
+        test('finds all args with nested function calls', function () {
+            const lines = [
+                'void OnTick() {',
+                '  Print(foo(bar), baz);', // BP here (line 2)
+                '}',
+            ];
+            const vars = findFunctionCallArgs(lines, 2);
+            assert.ok(!vars.includes('foo'), 'should not include nested function name');
+            assert.ok(vars.includes('bar'), 'should find bar inside nested call');
+            assert.ok(vars.includes('baz'), 'should find baz after nested call');
+        });
+
         test('returns empty with no function calls', function () {
             const lines = [
                 'void OnTick() {',
@@ -1020,6 +1032,18 @@ suite('debugInstrumentation', function () {
             const joined = lines.join('\n');
             assert.ok(joined.includes('MQL_DBG_BWATCH_INT("x", x)'), 'regular watch');
             assert.ok(joined.includes('SymbolInfoDouble(_Symbol, SYMBOL_ASK)'), 'expression watch');
+        });
+
+        test('expression watch label with quotes is escaped', function () {
+            const vars = [
+                { name: 'a["key"]', type: 'string', isExpression: true, expr: 'a["key"]' },
+            ];
+            const lines = buildProbeInjection(0, 'bp_test_1', vars, '');
+            const joined = lines.join('\n');
+            // The label should have escaped quotes: a[\"key\"]
+            assert.ok(joined.includes('a[\\"key\\"]'), 'should escape quotes in label');
+            // The expression should remain verbatim
+            assert.ok(joined.includes('a["key"]'), 'expression should be verbatim');
         });
     });
 

--- a/test/debugInstrumentation.test.js
+++ b/test/debugInstrumentation.test.js
@@ -4,6 +4,8 @@ const { _test } = require('../src/debugInstrumentation');
 const {
     MqlLineClassifier,
     isConditionSafe,
+    isExpressionSafe,
+    SAFE_READONLY_FUNCTIONS,
     findInjectionPoint,
     parseWatchAnnotations,
     macroForType,
@@ -13,6 +15,10 @@ const {
     sanitizeCondition,
     buildLogExpression,
     buildProbeInjection,
+    scoreVariableRelevance,
+    findEnclosingControlFlowVars,
+    findFunctionCallArgs,
+    collectWatchVars,
 } = _test;
 
 suite('debugInstrumentation', function () {
@@ -107,6 +113,102 @@ suite('debugInstrumentation', function () {
     });
 
     // =========================================================================
+    // isExpressionSafe
+    // =========================================================================
+
+    suite('isExpressionSafe', function () {
+        test('allows simple variable access', function () {
+            const r = isExpressionSafe('myVar');
+            assert.strictEqual(r.safe, true);
+        });
+
+        test('allows arithmetic expressions', function () {
+            const r = isExpressionSafe('(a + b) * 2.0');
+            assert.strictEqual(r.safe, true);
+        });
+
+        test('allows allowlisted function calls', function () {
+            assert.strictEqual(isExpressionSafe('SymbolInfoDouble(_Symbol, SYMBOL_ASK)').safe, true);
+            assert.strictEqual(isExpressionSafe('OrdersTotal()').safe, true);
+            assert.strictEqual(isExpressionSafe('MathAbs(x - y)').safe, true);
+            assert.strictEqual(isExpressionSafe('ArraySize(arr)').safe, true);
+            assert.strictEqual(isExpressionSafe('StringLen(s)').safe, true);
+        });
+
+        test('allows nested allowlisted calls', function () {
+            const r = isExpressionSafe('NormalizeDouble(SymbolInfoDouble(_Symbol, SYMBOL_ASK), 5)');
+            assert.strictEqual(r.safe, true);
+        });
+
+        test('allows type casts that look like function calls', function () {
+            assert.strictEqual(isExpressionSafe('int(myDouble)').safe, true);
+            assert.strictEqual(isExpressionSafe('double(myInt) + 1.0').safe, true);
+            assert.strictEqual(isExpressionSafe('string(value)').safe, true);
+        });
+
+        test('rejects dangerous function calls — OrderSend', function () {
+            const r = isExpressionSafe('OrderSend(request, result)');
+            assert.strictEqual(r.safe, false);
+            assert.ok(r.reason.includes('OrderSend'));
+        });
+
+        test('rejects FileDelete', function () {
+            const r = isExpressionSafe('FileDelete("data.csv")');
+            assert.strictEqual(r.safe, false);
+            assert.ok(r.reason.includes('FileDelete'));
+        });
+
+        test('rejects WebRequest', function () {
+            const r = isExpressionSafe('WebRequest("POST", url, headers, timeout, data, res, resHeaders)');
+            assert.strictEqual(r.safe, false);
+            assert.ok(r.reason.includes('WebRequest'));
+        });
+
+        test('rejects unknown user functions', function () {
+            const r = isExpressionSafe('MyCustomFunction(x)');
+            assert.strictEqual(r.safe, false);
+            assert.ok(r.reason.includes('MyCustomFunction'));
+        });
+
+        test('rejects semicolons (statement injection)', function () {
+            const r = isExpressionSafe('x; OrderSend(req, res)');
+            assert.strictEqual(r.safe, false);
+            assert.strictEqual(r.reason, 'semicolons not allowed');
+        });
+
+        test('rejects preprocessor directives', function () {
+            const r = isExpressionSafe('#include <evil.mqh>');
+            assert.strictEqual(r.safe, false);
+            assert.strictEqual(r.reason, 'preprocessor directives not allowed');
+        });
+
+        test('rejects unbalanced delimiters', function () {
+            const r = isExpressionSafe('SymbolInfoDouble(_Symbol');
+            assert.strictEqual(r.safe, false);
+            assert.strictEqual(r.reason, 'unbalanced delimiters');
+        });
+
+        test('rejects empty/null', function () {
+            assert.strictEqual(isExpressionSafe('').safe, false);
+            assert.strictEqual(isExpressionSafe(null).safe, false);
+            assert.strictEqual(isExpressionSafe(undefined).safe, false);
+        });
+
+        test('SAFE_READONLY_FUNCTIONS contains expected entries', function () {
+            assert.ok(SAFE_READONLY_FUNCTIONS.has('SymbolInfoDouble'));
+            assert.ok(SAFE_READONLY_FUNCTIONS.has('OrdersTotal'));
+            assert.ok(SAFE_READONLY_FUNCTIONS.has('MathAbs'));
+            assert.ok(SAFE_READONLY_FUNCTIONS.has('ArraySize'));
+            assert.ok(SAFE_READONLY_FUNCTIONS.has('TimeCurrent'));
+            // Should NOT contain side-effecting functions
+            assert.ok(!SAFE_READONLY_FUNCTIONS.has('OrderSend'));
+            assert.ok(!SAFE_READONLY_FUNCTIONS.has('FileDelete'));
+            assert.ok(!SAFE_READONLY_FUNCTIONS.has('WebRequest'));
+            assert.ok(!SAFE_READONLY_FUNCTIONS.has('Print'));
+        });
+    });
+
+    // =========================================================================
     // findInjectionPoint
     // =========================================================================
 
@@ -193,8 +295,9 @@ suite('debugInstrumentation', function () {
                 '  int x = 5;',         // bp on line 3
                 '}',
             ];
-            const vars = parseWatchAnnotations(lines, 3);
-            assert.deepStrictEqual(vars, ['myVar', 'otherVar']);
+            const result = parseWatchAnnotations(lines, 3);
+            assert.deepStrictEqual(result.names, ['myVar', 'otherVar']);
+            assert.deepStrictEqual(result.expressions, []);
         });
 
         test('returns empty when no annotation', function () {
@@ -203,7 +306,9 @@ suite('debugInstrumentation', function () {
                 '  int x = 5;',
                 '}',
             ];
-            assert.deepStrictEqual(parseWatchAnnotations(lines, 2), []);
+            const result = parseWatchAnnotations(lines, 2);
+            assert.deepStrictEqual(result.names, []);
+            assert.deepStrictEqual(result.expressions, []);
         });
 
         test('deduplicates variable names', function () {
@@ -212,8 +317,102 @@ suite('debugInstrumentation', function () {
                 '// @watch b c',
                 'int x;',
             ];
-            const vars = parseWatchAnnotations(lines, 3);
-            assert.deepStrictEqual(vars, ['a', 'b', 'c']);
+            const result = parseWatchAnnotations(lines, 3);
+            assert.deepStrictEqual(result.names, ['a', 'b', 'c']);
+        });
+
+        test('parses typed expression watch', function () {
+            const lines = [
+                'void OnTick() {',
+                '  // @watch:double SymbolInfoDouble(_Symbol, SYMBOL_ASK)',
+                '  Print("test");',  // bp on line 3
+                '}',
+            ];
+            const result = parseWatchAnnotations(lines, 3);
+            assert.strictEqual(result.expressions.length, 1);
+            assert.strictEqual(result.expressions[0].type, 'double');
+            assert.strictEqual(result.expressions[0].expr, 'SymbolInfoDouble(_Symbol, SYMBOL_ASK)');
+        });
+
+        test('mixed simple and typed annotations', function () {
+            const lines = [
+                '// @watch x y',
+                '// @watch:int OrdersTotal()',
+                'int z;',  // bp on line 3
+            ];
+            const result = parseWatchAnnotations(lines, 3);
+            assert.deepStrictEqual(result.names, ['x', 'y']);
+            assert.strictEqual(result.expressions.length, 1);
+            assert.strictEqual(result.expressions[0].type, 'int');
+        });
+
+        test('rejects unsafe expression watches and reports them', function () {
+            const lines = [
+                '// @watch:int OrderSend(request, result)',
+                'int z;',  // bp on line 2
+            ];
+            const result = parseWatchAnnotations(lines, 2);
+            assert.strictEqual(result.expressions.length, 0, 'should not include unsafe expression');
+            assert.strictEqual(result.rejected.length, 1, 'should report rejection');
+            assert.ok(result.rejected[0].reason.includes('OrderSend'));
+            assert.strictEqual(result.rejected[0].line, 1);
+        });
+
+        test('accepts safe and rejects unsafe in same block', function () {
+            const lines = [
+                '// @watch:double SymbolInfoDouble(_Symbol, SYMBOL_ASK)',
+                '// @watch:int FileDelete("bad.csv")',
+                'Print("test");',  // bp on line 3
+            ];
+            const result = parseWatchAnnotations(lines, 3);
+            assert.strictEqual(result.expressions.length, 1, 'safe expression accepted');
+            assert.strictEqual(result.expressions[0].expr, 'SymbolInfoDouble(_Symbol, SYMBOL_ASK)');
+            assert.strictEqual(result.rejected.length, 1, 'unsafe expression rejected');
+            assert.ok(result.rejected[0].reason.includes('FileDelete'));
+        });
+
+        test('@watch!: bypasses safety checks for dangerous calls', function () {
+            const lines = [
+                '// @watch!:int OrderSend(request, result)',
+                'int z;',  // bp on line 2
+            ];
+            const result = parseWatchAnnotations(lines, 2);
+            assert.strictEqual(result.expressions.length, 1, 'unsafe expression allowed with !');
+            assert.strictEqual(result.expressions[0].expr, 'OrderSend(request, result)');
+            assert.strictEqual(result.expressions[0].type, 'int');
+            assert.strictEqual(result.rejected.length, 0, 'no rejections');
+        });
+
+        test('@watch!: still rejects unbalanced delimiters', function () {
+            const lines = [
+                '// @watch!:int OrderSend(request',
+                'int z;',  // bp on line 2
+            ];
+            const result = parseWatchAnnotations(lines, 2);
+            assert.strictEqual(result.expressions.length, 0, 'unbalanced still rejected');
+            assert.strictEqual(result.rejected.length, 1);
+            assert.strictEqual(result.rejected[0].reason, 'unbalanced delimiters');
+        });
+
+        test('@watch!: allows user-defined functions', function () {
+            const lines = [
+                '// @watch!:double MyCustomCalculation(x, y, z)',
+                'Print("test");',  // bp on line 2
+            ];
+            const result = parseWatchAnnotations(lines, 2);
+            assert.strictEqual(result.expressions.length, 1);
+            assert.strictEqual(result.expressions[0].expr, 'MyCustomCalculation(x, y, z)');
+        });
+
+        test('@watch: without ! rejects same user-defined function', function () {
+            const lines = [
+                '// @watch:double MyCustomCalculation(x, y, z)',
+                'Print("test");',  // bp on line 2
+            ];
+            const result = parseWatchAnnotations(lines, 2);
+            assert.strictEqual(result.expressions.length, 0, 'rejected without !');
+            assert.strictEqual(result.rejected.length, 1);
+            assert.ok(result.rejected[0].reason.includes('MyCustomCalculation'));
         });
     });
 
@@ -540,8 +739,10 @@ suite('debugInstrumentation', function () {
             const lines = buildProbeInjection(0, 'bp_test_1', [], '');
             const joined = lines.join('\n');
             assert.ok(joined.includes('MqlDebugProbeCheck(0)'), 'should check probe');
-            assert.ok(joined.includes('MQL_DBG_BREAK("bp_test_1")'), 'should emit BREAK');
+            assert.ok(joined.includes('MQL_DBG_BBREAK("bp_test_1")'), 'should emit BREAK (batch)');
             assert.ok(joined.includes('MQL_DBG_PAUSE'), 'should contain PAUSE');
+            assert.ok(joined.includes('MqlDebugBatchStart()'), 'should start batch');
+            assert.ok(joined.includes('MqlDebugBatchFlush()'), 'should flush batch');
         });
 
         test('probe without logMessage has runtime logpoint check to skip PAUSE', function () {
@@ -577,29 +778,289 @@ suite('debugInstrumentation', function () {
             assert.ok(joined.includes('&& (x > 5)'), 'should include condition expression');
         });
 
-        test('probe with watch vars includes watch macros', function () {
+        test('probe with watch vars includes batch watch macros', function () {
             const vars = [
                 { name: 'count', type: 'int' },
                 { name: 'price', type: 'double' },
             ];
             const lines = buildProbeInjection(0, 'bp_test_1', vars, '');
             const joined = lines.join('\n');
-            assert.ok(joined.includes('MQL_DBG_WATCH_INT("count", count)'), 'should watch int');
-            assert.ok(joined.includes('MQL_DBG_WATCH_DBL("price", price)'), 'should watch double');
+            assert.ok(joined.includes('MQL_DBG_BWATCH_INT("count", count)'), 'should watch int (batch)');
+            assert.ok(joined.includes('MQL_DBG_BWATCH_DBL("price", price)'), 'should watch double (batch)');
         });
 
         test('no-logMessage fallback: logpoint emits BREAK + watches without PAUSE', function () {
             const vars = [{ name: 'x', type: 'int' }];
             const lines = buildProbeInjection(7, 'bp_test_7', vars, '');
             const joined = lines.join('\n');
-            // Should have BREAK and watch in the main body (before logpoint check)
-            assert.ok(joined.includes('MQL_DBG_BREAK("bp_test_7")'), 'should have BREAK');
-            assert.ok(joined.includes('MQL_DBG_WATCH_INT("x", x)'), 'should have watch');
+            // Should have batch BREAK and watch in the main body (before logpoint check)
+            assert.ok(joined.includes('MQL_DBG_BBREAK("bp_test_7")'), 'should have BREAK (batch)');
+            assert.ok(joined.includes('MQL_DBG_BWATCH_INT("x", x)'), 'should have watch (batch)');
             // PAUSE is conditional on NOT being a logpoint
             assert.ok(joined.includes('!MqlDebugIsLogpoint(7)'),
                 'should guard PAUSE with logpoint check');
             assert.ok(joined.includes('MQL_DBG_PAUSE'),
                 'should contain PAUSE in break branch');
+        });
+    });
+
+    // =========================================================================
+    // scoreVariableRelevance
+    // =========================================================================
+
+    suite('scoreVariableRelevance', function () {
+        test('variable assigned on BP line gets highest score', function () {
+            const lines = ['void OnTick() {', '  int x = 5;', '  x = 10;', '  Print(x);', '}'];
+            const score = scoreVariableRelevance(lines, 3, 'x'); // line 3 is "x = 10;"
+            assert.ok(score >= 10, `expected >= 10 for BP-line assignment, got ${score}`);
+        });
+
+        test('variable assigned 2 lines before BP scores high', function () {
+            const lines = ['void OnTick() {', '  int x = 5;', '  double y = 1.0;', '  Print(x);', '}'];
+            const score = scoreVariableRelevance(lines, 4, 'x'); // x assigned at line 2, BP at line 4
+            assert.ok(score > 0, `expected > 0, got ${score}`);
+        });
+
+        test('unreferenced variable scores zero', function () {
+            const lines = ['void OnTick() {', '  int x = 5;', '  Print(y);', '}'];
+            const score = scoreVariableRelevance(lines, 3, 'z'); // z not in code at all
+            assert.strictEqual(score, 0);
+        });
+
+        test('frequently used variable gets frequency bonus', function () {
+            const lines = [
+                'void OnTick() {',
+                '  int x = arr[x] + x;',
+                '  if (x > 0) x++;',
+                '  Print(x);', // BP here (line 4)
+                '}',
+            ];
+            const score = scoreVariableRelevance(lines, 4, 'x');
+            // x appears on multiple lines near BP, should get frequency bonus
+            assert.ok(score >= 3, `expected >= 3 for frequent var, got ${score}`);
+        });
+    });
+
+    // =========================================================================
+    // findEnclosingControlFlowVars
+    // =========================================================================
+
+    suite('findEnclosingControlFlowVars', function () {
+        test('detects variables in if-condition', function () {
+            const lines = [
+                'void OnTick() {',
+                '  int x = 5;',
+                '  if (x > threshold) {',
+                '    Print(x);', // BP here (line 4)
+                '  }',
+                '}',
+            ];
+            const vars = findEnclosingControlFlowVars(lines, 4);
+            assert.ok(vars.includes('x'), 'should find x');
+            assert.ok(vars.includes('threshold'), 'should find threshold');
+        });
+
+        test('detects loop iterator in for-loop', function () {
+            const lines = [
+                'void OnTick() {',
+                '  for (int i = 0; i < count; i++) {',
+                '    arr[i] = 0;', // BP here (line 3)
+                '  }',
+                '}',
+            ];
+            const vars = findEnclosingControlFlowVars(lines, 3);
+            assert.ok(vars.includes('i'), 'should find i');
+            assert.ok(vars.includes('count'), 'should find count');
+        });
+
+        test('detects while-condition variables', function () {
+            const lines = [
+                'void OnTick() {',
+                '  while (pos >= 0) {',
+                '    Process(pos);', // BP here (line 3)
+                '  }',
+                '}',
+            ];
+            const vars = findEnclosingControlFlowVars(lines, 3);
+            assert.ok(vars.includes('pos'), 'should find pos');
+        });
+
+        test('returns empty when not inside control flow', function () {
+            const lines = [
+                'void OnTick() {',
+                '  int x = 5;', // BP here (line 2)
+                '}',
+            ];
+            const vars = findEnclosingControlFlowVars(lines, 2);
+            assert.deepStrictEqual(vars, []);
+        });
+    });
+
+    // =========================================================================
+    // findFunctionCallArgs
+    // =========================================================================
+
+    suite('findFunctionCallArgs', function () {
+        test('detects arguments on BP line', function () {
+            const lines = [
+                'void OnTick() {',
+                '  OrderSend(request, result);', // BP here (line 2)
+                '}',
+            ];
+            const vars = findFunctionCallArgs(lines, 2);
+            assert.ok(vars.includes('request'), 'should find request');
+            assert.ok(vars.includes('result'), 'should find result');
+        });
+
+        test('detects arguments on adjacent lines', function () {
+            const lines = [
+                'void OnTick() {',
+                '  Print(msg);',
+                '  int x = 0;', // BP here (line 3)
+                '  Send(data);',
+                '}',
+            ];
+            const vars = findFunctionCallArgs(lines, 3);
+            assert.ok(vars.includes('msg'), 'should find msg from line before');
+            assert.ok(vars.includes('data'), 'should find data from line after');
+        });
+
+        test('skips nested function calls as arguments', function () {
+            const lines = [
+                'void OnTick() {',
+                '  Print(StringLen(text));', // BP here (line 2)
+                '}',
+            ];
+            const vars = findFunctionCallArgs(lines, 2);
+            // StringLen is a function call, should not appear as a variable
+            assert.ok(!vars.includes('StringLen'), 'should not include function name');
+            assert.ok(vars.includes('text'), 'should find text');
+        });
+
+        test('returns empty with no function calls', function () {
+            const lines = [
+                'void OnTick() {',
+                '  int x = 5;', // BP here (line 2)
+                '}',
+            ];
+            const vars = findFunctionCallArgs(lines, 2);
+            assert.deepStrictEqual(vars, []);
+        });
+    });
+
+    // =========================================================================
+    // macroForType batch mode
+    // =========================================================================
+
+    suite('macroForType batch mode', function () {
+        test('returns batch macro for int', function () {
+            assert.strictEqual(macroForType('int', false, true), 'MQL_DBG_BWATCH_INT');
+        });
+
+        test('returns batch macro for double', function () {
+            assert.strictEqual(macroForType('double', false, true), 'MQL_DBG_BWATCH_DBL');
+        });
+
+        test('returns batch macro for string', function () {
+            assert.strictEqual(macroForType('string', false, true), 'MQL_DBG_BWATCH_STR');
+        });
+
+        test('returns batch array macro for int[]', function () {
+            assert.strictEqual(macroForType('int', true, true), 'MQL_DBG_BWATCH_ARRAY_INT');
+        });
+
+        test('returns batch fallback for unknown type', function () {
+            assert.strictEqual(macroForType(null, false, true), 'MQL_DBG_BWATCH');
+        });
+
+        test('returns non-batch macro when batch=false', function () {
+            assert.strictEqual(macroForType('int', false, false), 'MQL_DBG_WATCH_INT');
+        });
+
+        test('batch enum type returns BWATCH_INT', function () {
+            assert.strictEqual(macroForType('ENUM_ORDER_TYPE', false, true), 'MQL_DBG_BWATCH_INT');
+        });
+    });
+
+    // =========================================================================
+    // buildProbeInjection — expression watches
+    // =========================================================================
+
+    suite('buildProbeInjection — expression watches', function () {
+        test('expression watch injects expression verbatim as value', function () {
+            const vars = [
+                { name: 'SymbolInfoDouble(...)', type: 'double', isExpression: true, expr: 'SymbolInfoDouble(_Symbol, SYMBOL_ASK)' },
+            ];
+            const lines = buildProbeInjection(0, 'bp_test_1', vars, '');
+            const joined = lines.join('\n');
+            assert.ok(
+                joined.includes('MQL_DBG_BWATCH_DBL("SymbolInfoDouble(...)", SymbolInfoDouble(_Symbol, SYMBOL_ASK))'),
+                'should inject expression as value argument'
+            );
+        });
+
+        test('expression watch with int type uses BWATCH_INT', function () {
+            const vars = [
+                { name: 'OrdersTotal()', type: 'int', isExpression: true, expr: 'OrdersTotal()' },
+            ];
+            const lines = buildProbeInjection(0, 'bp_test_1', vars, '');
+            const joined = lines.join('\n');
+            assert.ok(
+                joined.includes('MQL_DBG_BWATCH_INT("OrdersTotal()", OrdersTotal())'),
+                'should use int macro for int expression'
+            );
+        });
+
+        test('mixed regular and expression watches', function () {
+            const vars = [
+                { name: 'x', type: 'int' },
+                { name: 'Ask price', type: 'double', isExpression: true, expr: 'SymbolInfoDouble(_Symbol, SYMBOL_ASK)' },
+            ];
+            const lines = buildProbeInjection(0, 'bp_test_1', vars, '');
+            const joined = lines.join('\n');
+            assert.ok(joined.includes('MQL_DBG_BWATCH_INT("x", x)'), 'regular watch');
+            assert.ok(joined.includes('SymbolInfoDouble(_Symbol, SYMBOL_ASK)'), 'expression watch');
+        });
+    });
+
+    // =========================================================================
+    // collectWatchVars — integration
+    // =========================================================================
+
+    suite('collectWatchVars — integration', function () {
+        const emptyTypeDB = { classMap: new Map(), globalMap: new Map() };
+
+        test('collects locals and sorts by relevance', function () {
+            const lines = [
+                'void OnTick() {',
+                '  int x = 0;',
+                '  int unused = 99;',
+                '  double y = 1.0;',
+                '  y = Ask;',         // y is assigned here (line 5), 1 line before BP
+                '  Print(y);',        // BP on line 6 — y is referenced here
+                '}',
+            ];
+            const vars = collectWatchVars(lines, 6, emptyTypeDB, false);
+            const names = vars.map(v => v.name);
+            assert.ok(names.includes('x'), 'should include x');
+            assert.ok(names.includes('y'), 'should include y');
+            assert.ok(names.includes('unused'), 'should include unused');
+            // y (assigned 1 line before BP, referenced on BP line) should rank above unused (far away, no refs)
+            assert.ok(names.indexOf('y') < names.indexOf('unused'), 'y should sort before unused');
+        });
+
+        test('includes expression watches from @watch:type annotations', function () {
+            const lines = [
+                'void OnTick() {',
+                '  // @watch:double SymbolInfoDouble(_Symbol, SYMBOL_ASK)',
+                '  int x = 5;',   // BP on line 3
+                '}',
+            ];
+            const vars = collectWatchVars(lines, 3, emptyTypeDB, false);
+            const exprWatch = vars.find(v => v.isExpression);
+            assert.ok(exprWatch, 'should include expression watch');
+            assert.strictEqual(exprWatch.type, 'double');
+            assert.strictEqual(exprWatch.expr, 'SymbolInfoDouble(_Symbol, SYMBOL_ASK)');
         });
     });
 });


### PR DESCRIPTION
## Summary
- **Smarter variable detection**: assignment-proximity scoring, control-flow awareness (`if`/`for`/`while`/`switch` condition vars), function call argument detection, and auto-expansion of small structs (<=8 primitive fields) at default detail level
- **Expression watches** (`// @watch:type expr`): watch arbitrary MQL expressions with a security allowlist for function calls; `// @watch!:type expr` bypasses the allowlist for advanced users
- **Batch I/O**: all BREAK+WATCH writes are accumulated into a single `FileWriteString+FileFlush` per probe, reducing file I/O by up to 10x
- **Variable timeline**: expand any variable in the Variables panel to see its value history across multiple breakpoint hits
- **CodeLens watch suggestions**: "Add @watch annotation" lens appears on breakpoint lines without nearby `@watch` comments
- **Security**: expression watches validate function calls against `SAFE_READONLY_FUNCTIONS` (~120 read-only MQL built-ins); semicolons and preprocessor directives are blocked; rejected expressions show a VS Code warning with the reason
- **Changelog and startup page** updated to document all new features

## Changed files
| File | Changes |
|------|---------|
| `src/debugInstrumentation.js` | Scoring, control-flow/arg detection, expression watch parsing with safety validation, batch macro support, small struct auto-expand |
| `src/debugAdapter.js` | Variable timeline via expandable `variablesReference` |
| `src/debugStateStore.js` | Previous-hit value tracking, `getVariableHistory()` |
| `files/MqlDebug.mqh` | Batch I/O macros (`MqlDebugBatchStart/Add/Flush`, `MQL_DBG_BBREAK/BWATCH_*`) |
| `src/debugCodeLens.js` | **New** — CodeLens provider + insert command |
| `src/extension.js` | Register CodeLens provider |
| `CHANGELOG.md` | New feature entries under Unreleased |
| `media/tabs/tab-debugger.html` | Updated startup page with new features |
| `test/debugInstrumentation.test.js` | 20 new tests (expression safety, scoring, control-flow, batch macros) |
| `test/debugFeatures.test.js` | Value-change tracking and variable history tests |

## Test plan
- [x] All 341 tests pass (`node test/runUnitTests.js`)
- [ ] Manual: set breakpoint in a loop, verify Variables panel shows values ranked by relevance
- [ ] Manual: add `// @watch:double SymbolInfoDouble(_Symbol, SYMBOL_ASK)`, verify expression value appears
- [ ] Manual: add `// @watch:int OrderSend(req, res)` (without `!`), verify rejection warning
- [ ] Manual: add `// @watch!:int OrderSend(req, res)` (with `!`), verify it compiles
- [ ] Manual: hit a breakpoint 5+ times, expand a variable to see value history
- [ ] Manual: verify CodeLens "Add @watch" appears on breakpoint lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)