### PR TITLE
Add UTF-8 mirror for MetaQuotes include directories

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,10 +1,18 @@
 {
   "permissions": {
     "allow": [
-      "Bash(node --check \"c:/Users/Alessandro/source/MQL_clangd/src/debugInstrumentation.js\")",
-      "Bash(node --check \"c:/Users/Alessandro/source/MQL_clangd/src/debugAdapter.js\")",
-      "Bash(node --check \"c:/Users/Alessandro/source/MQL_clangd/src/debugStateStore.js\")",
-      "Bash(node test_instr_temp.js)"
+      "mcp__smart-terminal__terminal_run",
+      "mcp__smart-terminal__terminal_start",
+      "mcp__smart-terminal__terminal_exec",
+      "mcp__smart-terminal__terminal_list",
+      "Skill(update-config)",
+      "WebFetch(domain:www.anthropic.com)",
+      "WebFetch(domain:claude.com)",
+      "WebFetch(domain:docs.claude.com)",
+      "WebSearch",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:gist.github.com)",
+      "Bash(node *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,18 +1,6 @@
 {
   "permissions": {
     "allow": [
-      "mcp__smart-terminal__terminal_run",
-      "mcp__smart-terminal__terminal_start",
-      "mcp__smart-terminal__terminal_exec",
-      "mcp__smart-terminal__terminal_list",
-      "Skill(update-config)",
-      "WebFetch(domain:www.anthropic.com)",
-      "WebFetch(domain:claude.com)",
-      "WebFetch(domain:docs.claude.com)",
-      "WebSearch",
-      "WebFetch(domain:github.com)",
-      "WebFetch(domain:gist.github.com)",
-      "Bash(node *)"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -243,6 +243,11 @@
                     "default": "node",
                     "description": "Path to the Node.js executable used to start TradeReportServer. Use the default ('node') if Node is on your PATH, or provide an absolute path for custom Node installations."
                 },
+                "mql_tools.Clangd.UseUtf8Mirror": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Mirror the MetaQuotes include directory as UTF-8 so clangd can index UTF-16-encoded library headers (e.g. `Generic/`, `Expert/`). The mirror lives under `%LOCALAPPDATA%/mql-clangd/mirror` (or `~/.cache/mql-clangd/mirror`) and is refreshed incrementally when `MQL: Create configuration` runs. Disable to use the original include paths directly."
+                },
                 "mql_tools.Clangd.PreserveSuppressions": {
                     "type": "string",
                     "enum": [

--- a/src/createProperties.js
+++ b/src/createProperties.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const pathModule = require('path');
 const { parseIncludes, resolveIncludePath } = require('./compileTargetResolver');
 const { ensureUtf8Mirror } = require('./utf8Mirror');
+const { decodeTextBuffer } = require('./textDecoding');
 
 /**
  * Normalizes paths for clangd (forward slashes).
@@ -258,7 +259,8 @@ async function buildIncludeChain(entryPointPath, workspaceRoot, includeDir) {
     async function walk(filePath) {
         let content;
         try {
-            content = await fs.promises.readFile(filePath, 'utf8');
+            const buf = await fs.promises.readFile(filePath);
+            content = decodeTextBuffer(buf);
         } catch {
             return; // file unreadable — skip
         }
@@ -405,7 +407,8 @@ const includeSnapshotCache = new Map();
  */
 async function snapshotIncludes(filePath) {
     try {
-        const content = await fs.promises.readFile(filePath, 'utf8');
+        const buf = await fs.promises.readFile(filePath);
+        const content = decodeTextBuffer(buf);
         return JSON.stringify(parseIncludes(content));
     } catch {
         return '';
@@ -828,11 +831,21 @@ async function CreateProperties(force = false) {
         if (fs.existsSync(sub)) resolved = sub;
         else if (fs.existsSync(dir)) resolved = dir;
         else return null;
-        return useUtf8Mirror ? await ensureUtf8Mirror(resolved) : resolved;
+        if (useUtf8Mirror) {
+            try {
+                return await ensureUtf8Mirror(resolved);
+            } catch (err) {
+                console.warn(`MQL Tools: UTF-8 mirror failed for ${resolved}: ${err && err.message}`);
+                return resolved;
+            }
+        }
+        return resolved;
     }
 
-    const inc4Root = await resolveExternalIncRoot(inc4Dir);
-    const inc5Root = await resolveExternalIncRoot(inc5Dir);
+    const [inc4Root, inc5Root] = await Promise.all([
+        resolveExternalIncRoot(inc4Dir),
+        resolveExternalIncRoot(inc5Dir)
+    ]);
     const inc4Flag = inc4Root ? `-I${normalizePath(inc4Root)}` : null;
     const inc5Flag = inc5Root ? `-I${normalizePath(inc5Root)}` : null;
     const primaryIncFlag = workspaceVersion === 'mql4' ? inc4Flag : inc5Flag;
@@ -860,6 +873,11 @@ async function CreateProperties(force = false) {
 
     // Resolve external include directory for include-chain resolution.
     // Reuses resolveExternalIncRoot so the chain walker reads the mirror too.
+    // NOTE: ensureUtf8Mirror may return the original source directory on error
+    // (e.g. if mirroring fails). In that case buildIncludeChain reads files with
+    // readFile(..., 'utf8') which will mis-decode UTF-16 headers. This is an
+    // acceptable degradation — no worse than pre-mirror behaviour — but means
+    // the include chain may be incomplete for MetaQuotes' UTF-16 library files.
     const resolvedExternalIncDir = (workspaceVersion === 'mql4' ? inc4Root : inc5Root) || undefined;
 
     // --- Generate compile_commands.json (reuse targetFiles from version detection scan) ---

--- a/src/createProperties.js
+++ b/src/createProperties.js
@@ -3,6 +3,7 @@ const vscode = require('vscode');
 const fs = require('fs');
 const pathModule = require('path');
 const { parseIncludes, resolveIncludePath } = require('./compileTargetResolver');
+const { ensureUtf8Mirror } = require('./utf8Mirror');
 
 /**
  * Normalizes paths for clangd (forward slashes).
@@ -816,16 +817,27 @@ async function CreateProperties(force = false) {
     const inc4Dir = resolvePathRelativeToWorkspace(configMql.Metaeditor.Include4Dir, workspacepath);
     const inc5Dir = resolvePathRelativeToWorkspace(configMql.Metaeditor.Include5Dir, workspacepath);
 
-    function resolveExternalIncFlag(dir) {
+    // Route external include dirs through a UTF-8 mirror so clangd and the
+    // include-chain walker see UTF-8 for MetaQuotes' UTF-16 library headers.
+    const useUtf8Mirror = configMql.Clangd?.UseUtf8Mirror !== false;
+
+    async function resolveExternalIncRoot(dir) {
         if (!dir || dir.length === 0) return null;
         const sub = pathModule.join(dir, 'Include');
-        if (fs.existsSync(sub)) return `-I${normalizePath(sub)}`;
-        if (fs.existsSync(dir)) return `-I${normalizePath(dir)}`;
-        return null;
+        let resolved;
+        if (fs.existsSync(sub)) resolved = sub;
+        else if (fs.existsSync(dir)) resolved = dir;
+        else return null;
+        return useUtf8Mirror ? await ensureUtf8Mirror(resolved) : resolved;
     }
 
-    const inc4Flag = resolveExternalIncFlag(inc4Dir);
-    const inc5Flag = resolveExternalIncFlag(inc5Dir);
+    async function resolveExternalIncFlag(dir) {
+        const resolved = await resolveExternalIncRoot(dir);
+        return resolved ? `-I${normalizePath(resolved)}` : null;
+    }
+
+    const inc4Flag = await resolveExternalIncFlag(inc4Dir);
+    const inc5Flag = await resolveExternalIncFlag(inc5Dir);
     const primaryIncFlag = workspaceVersion === 'mql4' ? inc4Flag : inc5Flag;
 
     const arrPath = [...baseFlags];
@@ -849,13 +861,9 @@ async function CreateProperties(force = false) {
     // C_Cpp.intelliSenseEngine is optional - silent mode since C++ extension may not be installed
     await safeConfigUpdate('C_Cpp.intelliSenseEngine', 'Disabled', vscode.ConfigurationTarget.Workspace, true);
 
-    // Resolve external include directory for include-chain resolution
-    function resolveExternalIncDir(dir) {
-        if (!dir || dir.length === 0) return undefined;
-        const sub = pathModule.join(dir, 'Include');
-        return fs.existsSync(sub) ? sub : (fs.existsSync(dir) ? dir : undefined);
-    }
-    const resolvedExternalIncDir = resolveExternalIncDir(workspaceVersion === 'mql4' ? inc4Dir : inc5Dir);
+    // Resolve external include directory for include-chain resolution.
+    // Reuses resolveExternalIncRoot so the chain walker reads the mirror too.
+    const resolvedExternalIncDir = (await resolveExternalIncRoot(workspaceVersion === 'mql4' ? inc4Dir : inc5Dir)) || undefined;
 
     // --- Generate compile_commands.json (reuse targetFiles from version detection scan) ---
     try {

--- a/src/createProperties.js
+++ b/src/createProperties.js
@@ -831,13 +831,10 @@ async function CreateProperties(force = false) {
         return useUtf8Mirror ? await ensureUtf8Mirror(resolved) : resolved;
     }
 
-    async function resolveExternalIncFlag(dir) {
-        const resolved = await resolveExternalIncRoot(dir);
-        return resolved ? `-I${normalizePath(resolved)}` : null;
-    }
-
-    const inc4Flag = await resolveExternalIncFlag(inc4Dir);
-    const inc5Flag = await resolveExternalIncFlag(inc5Dir);
+    const inc4Root = await resolveExternalIncRoot(inc4Dir);
+    const inc5Root = await resolveExternalIncRoot(inc5Dir);
+    const inc4Flag = inc4Root ? `-I${normalizePath(inc4Root)}` : null;
+    const inc5Flag = inc5Root ? `-I${normalizePath(inc5Root)}` : null;
     const primaryIncFlag = workspaceVersion === 'mql4' ? inc4Flag : inc5Flag;
 
     const arrPath = [...baseFlags];
@@ -863,7 +860,7 @@ async function CreateProperties(force = false) {
 
     // Resolve external include directory for include-chain resolution.
     // Reuses resolveExternalIncRoot so the chain walker reads the mirror too.
-    const resolvedExternalIncDir = (await resolveExternalIncRoot(workspaceVersion === 'mql4' ? inc4Dir : inc5Dir)) || undefined;
+    const resolvedExternalIncDir = (workspaceVersion === 'mql4' ? inc4Root : inc5Root) || undefined;
 
     // --- Generate compile_commands.json (reuse targetFiles from version detection scan) ---
     try {

--- a/src/extension.js
+++ b/src/extension.js
@@ -38,6 +38,7 @@ const { IconsInstallation } = require('./addIcon');
 const { Hover_log, DefinitionProvider, Hover_MQL, ItemProvider, HelpProvider, ColorProvider, MQLDocumentSymbolProvider, getObjItems, clearSymbolCache } = require('./provider');
 const { registerLightweightDiagnostics } = require('./lightweightDiagnostics');
 const { CreateProperties, generatePortableSwitch, resolvePathRelativeToWorkspace, haveIncludesChanged, CLANGD_BASE_SUPPRESSIONS } = require('./createProperties');
+const { decodeTextBuffer } = require('./textDecoding');
 const { resolveCompileTargets, setCompileTargets, resetCompileTargets, markIndexDirty, getCompileTargets } = require('./compileTargetResolver');
 const {
     toWineWindowsPath,
@@ -1045,31 +1046,6 @@ function extractPropertyVersion(text) {
     const version = match && match[1] ? match[1].trim() : '';
 
     return version || null;
-}
-
-function decodeTextBuffer(buffer) {
-    if (!Buffer.isBuffer(buffer) || buffer.length === 0) return '';
-
-    const hasUtf16LeBom = buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xfe;
-    if (hasUtf16LeBom) {
-        return buffer.toString('utf16le', 2);
-    }
-
-    const utf8Text = buffer.toString('utf8');
-    const sampleLength = Math.min(buffer.length, 256);
-    let nullByteCount = 0;
-
-    for (let i = 0; i < sampleLength; i++) {
-        if (buffer[i] === 0x00) {
-            nullByteCount++;
-        }
-    }
-
-    if (nullByteCount > sampleLength / 4) {
-        return buffer.toString('utf16le');
-    }
-
-    return utf8Text;
 }
 
 function getOpenDocumentText(filePath) {

--- a/src/textDecoding.js
+++ b/src/textDecoding.js
@@ -1,19 +1,6 @@
 'use strict';
 
-/**
- * Decode a Buffer to a string, auto-detecting UTF-16 LE (with or without BOM)
- * vs UTF-8.  MetaQuotes ships many MQL5 library headers as UTF-16 LE with BOM;
- * Node's default `readFile(path, 'utf8')` would return mojibake for those.
- *
- * Detection:
- *   - UTF-16 LE BOM (FF FE) → decode as utf16le, strip the BOM.
- *   - Otherwise, sample the first 256 bytes; if > 25% are 0x00, treat as
- *     UTF-16 LE without BOM.
- *   - Else, utf8.
- *
- * @param {Buffer} buffer
- * @returns {string}
- */
+// Decode buffer as UTF-16 LE (BOM or >25% null bytes in first 256) or UTF-8.
 function decodeTextBuffer(buffer) {
     if (!Buffer.isBuffer(buffer) || buffer.length === 0) return '';
 
@@ -36,7 +23,7 @@ function decodeTextBuffer(buffer) {
         return buffer.toString('utf16le');
     }
 
-    return utf8Text;
+    return utf8Text.charCodeAt(0) === 0xFEFF ? utf8Text.slice(1) : utf8Text;
 }
 
 module.exports = { decodeTextBuffer };

--- a/src/textDecoding.js
+++ b/src/textDecoding.js
@@ -9,7 +9,6 @@ function decodeTextBuffer(buffer) {
         return buffer.toString('utf16le', 2);
     }
 
-    const utf8Text = buffer.toString('utf8');
     const sampleLength = Math.min(buffer.length, 256);
     let nullByteCount = 0;
 
@@ -23,6 +22,7 @@ function decodeTextBuffer(buffer) {
         return buffer.toString('utf16le');
     }
 
+    const utf8Text = buffer.toString('utf8');
     return utf8Text.charCodeAt(0) === 0xFEFF ? utf8Text.slice(1) : utf8Text;
 }
 

--- a/src/textDecoding.js
+++ b/src/textDecoding.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * Decode a Buffer to a string, auto-detecting UTF-16 LE (with or without BOM)
+ * vs UTF-8.  MetaQuotes ships many MQL5 library headers as UTF-16 LE with BOM;
+ * Node's default `readFile(path, 'utf8')` would return mojibake for those.
+ *
+ * Detection:
+ *   - UTF-16 LE BOM (FF FE) → decode as utf16le, strip the BOM.
+ *   - Otherwise, sample the first 256 bytes; if > 25% are 0x00, treat as
+ *     UTF-16 LE without BOM.
+ *   - Else, utf8.
+ *
+ * @param {Buffer} buffer
+ * @returns {string}
+ */
+function decodeTextBuffer(buffer) {
+    if (!Buffer.isBuffer(buffer) || buffer.length === 0) return '';
+
+    const hasUtf16LeBom = buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xfe;
+    if (hasUtf16LeBom) {
+        return buffer.toString('utf16le', 2);
+    }
+
+    const utf8Text = buffer.toString('utf8');
+    const sampleLength = Math.min(buffer.length, 256);
+    let nullByteCount = 0;
+
+    for (let i = 0; i < sampleLength; i++) {
+        if (buffer[i] === 0x00) {
+            nullByteCount++;
+        }
+    }
+
+    if (nullByteCount > sampleLength / 4) {
+        return buffer.toString('utf16le');
+    }
+
+    return utf8Text;
+}
+
+module.exports = { decodeTextBuffer };

--- a/src/utf8Mirror.js
+++ b/src/utf8Mirror.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const fs = require('fs');
+const pathModule = require('path');
+const os = require('os');
+
+const { decodeTextBuffer } = require('./textDecoding');
+
+const MIRRORABLE_EXTS = new Set(['.mqh', '.mq5', '.mq4']);
+
+/**
+ * Compute the root directory for UTF-8 mirror copies.
+ *
+ *   Windows: %LOCALAPPDATA%/mql-clangd/mirror
+ *   other  : $HOME/.cache/mql-clangd/mirror
+ *
+ * @returns {string}
+ */
+function getMirrorRoot() {
+    const base = process.env.LOCALAPPDATA
+        ? process.env.LOCALAPPDATA
+        : pathModule.join(os.homedir(), '.cache');
+    return pathModule.join(base, 'mql-clangd', 'mirror');
+}
+
+/**
+ * Map a source path onto its mirror path.  The Windows drive letter becomes
+ * a regular path segment (e.g. `C:\Users\...` → `<root>/C/Users/...`) so the
+ * mirror is collision-free across drives and still greppable.
+ *
+ * @param {string} sourceAbsPath
+ * @returns {string}
+ */
+function mapToMirror(sourceAbsPath) {
+    const root = getMirrorRoot();
+    const driveMatch = /^([A-Za-z]):[\\/](.*)$/.exec(sourceAbsPath);
+    if (driveMatch) {
+        return pathModule.join(root, driveMatch[1].toUpperCase(), driveMatch[2]);
+    }
+    // POSIX-style absolute — strip the leading slash to keep path.join sane.
+    if (sourceAbsPath.startsWith('/')) {
+        return pathModule.join(root, sourceAbsPath.slice(1));
+    }
+    return pathModule.join(root, sourceAbsPath);
+}
+
+async function fileMtimeMs(filePath) {
+    try {
+        const st = await fs.promises.stat(filePath);
+        return st.mtimeMs;
+    } catch {
+        return null;
+    }
+}
+
+async function transcodeOne(srcPath, dstPath) {
+    const buffer = await fs.promises.readFile(srcPath);
+    const text = decodeTextBuffer(buffer);
+    await fs.promises.mkdir(pathModule.dirname(dstPath), { recursive: true });
+    await fs.promises.writeFile(dstPath, text, 'utf8');
+}
+
+async function walkAndMirror(srcDir, dstDir) {
+    let entries;
+    try {
+        entries = await fs.promises.readdir(srcDir, { withFileTypes: true });
+    } catch {
+        return;
+    }
+
+    for (const entry of entries) {
+        const srcPath = pathModule.join(srcDir, entry.name);
+        const dstPath = pathModule.join(dstDir, entry.name);
+
+        if (entry.isDirectory()) {
+            await walkAndMirror(srcPath, dstPath);
+            continue;
+        }
+        if (!entry.isFile()) continue;
+
+        const ext = pathModule.extname(entry.name).toLowerCase();
+        if (!MIRRORABLE_EXTS.has(ext)) continue;
+
+        const [srcMtime, dstMtime] = await Promise.all([
+            fileMtimeMs(srcPath),
+            fileMtimeMs(dstPath)
+        ]);
+        if (srcMtime === null) continue;
+        if (dstMtime !== null && dstMtime >= srcMtime) continue;
+
+        try {
+            await transcodeOne(srcPath, dstPath);
+        } catch (err) {
+            console.warn(`MQL Tools: failed to mirror ${srcPath}: ${err && err.message}`);
+        }
+    }
+}
+
+/**
+ * Ensure a UTF-8 mirror of `sourceIncludeDir` exists and is up to date.
+ * Returns the mirror directory path so callers can use it as the effective
+ * include root.  On any top-level failure, returns `sourceIncludeDir` so
+ * clangd falls back to the original tree (no worse than no-mirror).
+ *
+ * No-op (returns the input) when the source doesn't exist or isn't a dir.
+ *
+ * @param {string} sourceIncludeDir
+ * @returns {Promise<string>}
+ */
+async function ensureUtf8Mirror(sourceIncludeDir) {
+    if (!sourceIncludeDir || typeof sourceIncludeDir !== 'string') {
+        return sourceIncludeDir;
+    }
+
+    try {
+        const st = await fs.promises.stat(sourceIncludeDir);
+        if (!st.isDirectory()) return sourceIncludeDir;
+    } catch {
+        return sourceIncludeDir;
+    }
+
+    const mirrorDir = mapToMirror(pathModule.resolve(sourceIncludeDir));
+
+    try {
+        await fs.promises.mkdir(mirrorDir, { recursive: true });
+        await walkAndMirror(sourceIncludeDir, mirrorDir);
+        return mirrorDir;
+    } catch (err) {
+        console.warn(`MQL Tools: UTF-8 mirror unavailable for ${sourceIncludeDir}: ${err && err.message}`);
+        return sourceIncludeDir;
+    }
+}
+
+module.exports = {
+    ensureUtf8Mirror,
+    getMirrorRoot,
+    mapToMirror
+};

--- a/src/utf8Mirror.js
+++ b/src/utf8Mirror.js
@@ -7,6 +7,10 @@ const os = require('os');
 const { decodeTextBuffer } = require('./textDecoding');
 
 const MIRRORABLE_EXTS = new Set(['.mqh', '.mq5', '.mq4']);
+const STAMP_FILE = '.mirror-stamp';
+
+/** Per-mirror-root mutex: deduplicates concurrent ensureUtf8Mirror calls. */
+const _mirrorPromises = new Map();
 
 /**
  * Compute the root directory for UTF-8 mirror copies.
@@ -14,11 +18,12 @@ const MIRRORABLE_EXTS = new Set(['.mqh', '.mq5', '.mq4']);
  *   Windows: %LOCALAPPDATA%/mql-clangd/mirror
  *   other  : $HOME/.cache/mql-clangd/mirror
  *
- * @returns {string}
+ * Uses process.platform so the path follows platform semantics regardless
+ * of environment variable overrides.
  */
 function getMirrorRoot() {
-    const base = process.env.LOCALAPPDATA
-        ? process.env.LOCALAPPDATA
+    const base = process.platform === 'win32'
+        ? (process.env.LOCALAPPDATA || pathModule.join(os.homedir(), 'AppData', 'Local'))
         : pathModule.join(os.homedir(), '.cache');
     return pathModule.join(base, 'mql-clangd', 'mirror');
 }
@@ -28,8 +33,8 @@ function getMirrorRoot() {
  * a regular path segment (e.g. `C:\Users\...` → `<root>/C/Users/...`) so the
  * mirror is collision-free across drives and still greppable.
  *
- * @param {string} sourceAbsPath
- * @returns {string}
+ * UNC paths are normalised into an 'unc' subdirectory to prevent escaping
+ * the mirror root.
  */
 function mapToMirror(sourceAbsPath) {
     const root = getMirrorRoot();
@@ -37,7 +42,12 @@ function mapToMirror(sourceAbsPath) {
     if (driveMatch) {
         return pathModule.join(root, driveMatch[1].toUpperCase(), driveMatch[2]);
     }
-    // POSIX-style absolute — strip the leading slash to keep path.join sane.
+    // UNC paths (\\server\share\... or //server/share/...) — normalise into 'unc' subdirectory.
+    const uncMatch = /^[\\/]{2}([^\\/]+)[\\/](.*)$/.exec(sourceAbsPath);
+    if (uncMatch) {
+        return pathModule.join(root, 'unc', uncMatch[1], uncMatch[2]);
+    }
+    // POSIX-style absolute — strip the leading slash.
     if (sourceAbsPath.startsWith('/')) {
         return pathModule.join(root, sourceAbsPath.slice(1));
     }
@@ -64,66 +74,113 @@ async function walkAndMirror(srcDir, dstDir) {
     let entries;
     try {
         entries = await fs.promises.readdir(srcDir, { withFileTypes: true });
-    } catch {
-        return;
+    } catch (err) {
+        // Propagate so ensureUtf8Mirror can fall back to the source directory.
+        throw err;
     }
 
-    for (const entry of entries) {
+    // Prune stale mirror entries that no longer exist in the source.
+    const srcNames = new Set(entries.map(e => e.name));
+    let dstEntries;
+    try {
+        dstEntries = await fs.promises.readdir(dstDir, { withFileTypes: true });
+    } catch {
+        dstEntries = [];
+    }
+
+    await Promise.all(dstEntries
+        .filter(d => d.name !== STAMP_FILE && !srcNames.has(d.name))
+        .map(async dEntry => {
+            const stalePath = pathModule.join(dstDir, dEntry.name);
+            try {
+                if (dEntry.isDirectory()) {
+                    await fs.promises.rm(stalePath, { recursive: true });
+                } else if (MIRRORABLE_EXTS.has(pathModule.extname(dEntry.name).toLowerCase())) {
+                    await fs.promises.unlink(stalePath);
+                }
+            } catch (err) {
+                console.warn(`MQL Tools: failed to prune stale mirror entry ${stalePath}: ${err && err.message}`);
+            }
+        }));
+
+    await Promise.all(entries.map(async entry => {
         const srcPath = pathModule.join(srcDir, entry.name);
         const dstPath = pathModule.join(dstDir, entry.name);
 
         if (entry.isDirectory()) {
             await walkAndMirror(srcPath, dstPath);
-            continue;
+            return;
         }
-        if (!entry.isFile()) continue;
+        if (!entry.isFile()) return;
 
         const ext = pathModule.extname(entry.name).toLowerCase();
-        if (!MIRRORABLE_EXTS.has(ext)) continue;
+        if (!MIRRORABLE_EXTS.has(ext)) return;
 
         const [srcMtime, dstMtime] = await Promise.all([
             fileMtimeMs(srcPath),
             fileMtimeMs(dstPath)
         ]);
-        if (srcMtime === null) continue;
-        if (dstMtime !== null && dstMtime >= srcMtime) continue;
+        if (srcMtime === null) return;
+        if (dstMtime !== null && dstMtime >= srcMtime) return;
 
         try {
             await transcodeOne(srcPath, dstPath);
         } catch (err) {
             console.warn(`MQL Tools: failed to mirror ${srcPath}: ${err && err.message}`);
         }
-    }
+    }));
 }
 
 /**
  * Ensure a UTF-8 mirror of `sourceIncludeDir` exists and is up to date.
  * Returns the mirror directory path so callers can use it as the effective
- * include root.  On any top-level failure, returns `sourceIncludeDir` so
- * clangd falls back to the original tree (no worse than no-mirror).
+ * include root.  On any failure, returns `sourceIncludeDir` so clangd falls
+ * back to the original tree (no worse than no-mirror).
  *
- * No-op (returns the input) when the source doesn't exist or isn't a dir.
- *
- * @param {string} sourceIncludeDir
- * @returns {Promise<string>}
+ * Concurrent calls targeting the same mirror directory are deduplicated
+ * via an in-process mutex so only one walk runs at a time per root.
  */
 async function ensureUtf8Mirror(sourceIncludeDir) {
     if (!sourceIncludeDir || typeof sourceIncludeDir !== 'string') {
         return sourceIncludeDir;
     }
 
+    let srcStat;
     try {
-        const st = await fs.promises.stat(sourceIncludeDir);
-        if (!st.isDirectory()) return sourceIncludeDir;
+        srcStat = await fs.promises.stat(sourceIncludeDir);
+        if (!srcStat.isDirectory()) return sourceIncludeDir;
     } catch {
         return sourceIncludeDir;
     }
 
     const mirrorDir = mapToMirror(pathModule.resolve(sourceIncludeDir));
 
+    // Deduplicate concurrent mirror operations for the same directory.
+    let promise = _mirrorPromises.get(mirrorDir);
+    if (promise) return promise;
+
+    promise = _performMirror(sourceIncludeDir, mirrorDir, srcStat.mtimeMs);
+    _mirrorPromises.set(mirrorDir, promise);
+    try {
+        return await promise;
+    } finally {
+        _mirrorPromises.delete(mirrorDir);
+    }
+}
+
+async function _performMirror(sourceIncludeDir, mirrorDir, srcMtimeMs) {
+    const stampPath = pathModule.join(mirrorDir, STAMP_FILE);
     try {
         await fs.promises.mkdir(mirrorDir, { recursive: true });
+
+        // Skip full walk if mirror was built after the source dir was last modified.
+        const stampMtime = await fileMtimeMs(stampPath);
+        if (stampMtime !== null && stampMtime >= srcMtimeMs) {
+            return mirrorDir;
+        }
+
         await walkAndMirror(sourceIncludeDir, mirrorDir);
+        await fs.promises.writeFile(stampPath, '', 'utf8');
         return mirrorDir;
     } catch (err) {
         console.warn(`MQL Tools: UTF-8 mirror unavailable for ${sourceIncludeDir}: ${err && err.message}`);

--- a/src/utf8Mirror.js
+++ b/src/utf8Mirror.js
@@ -24,7 +24,7 @@ const _mirrorPromises = new Map();
 function getMirrorRoot() {
     const base = process.platform === 'win32'
         ? (process.env.LOCALAPPDATA || pathModule.join(os.homedir(), 'AppData', 'Local'))
-        : pathModule.join(os.homedir(), '.cache');
+        : (process.env.XDG_CACHE_HOME || pathModule.join(os.homedir(), '.cache'));
     return pathModule.join(base, 'mql-clangd', 'mirror');
 }
 
@@ -35,23 +35,36 @@ function getMirrorRoot() {
  *
  * UNC paths are normalised into an 'unc' subdirectory to prevent escaping
  * the mirror root.
+ *
+ * Callers must pass a fully resolved absolute path (e.g. from
+ * `pathModule.resolve`).  Relative or bare-drive forms are rejected to avoid
+ * bogus mirror names.
  */
 function mapToMirror(sourceAbsPath) {
+    if (typeof sourceAbsPath !== 'string') {
+        throw new Error('mapToMirror: sourceAbsPath must be a string, got ' + typeof sourceAbsPath);
+    }
+    // Reject non-absolute paths (including bare-drive forms like "C:" or "C:foo").
+    if (!pathModule.isAbsolute(sourceAbsPath) || /^[A-Za-z]:$/.test(sourceAbsPath) || /^[A-Za-z]:[^\\/]/.test(sourceAbsPath)) {
+        throw new Error('mapToMirror: expected a resolved absolute path (pass pathModule.resolve first); got: ' + sourceAbsPath);
+    }
     const root = getMirrorRoot();
-    const driveMatch = /^([A-Za-z]):[\\/](.*)$/.exec(sourceAbsPath);
+    const normalised = pathModule.normalize(sourceAbsPath);
+    const driveMatch = /^([A-Za-z]):[\\/](.*)$/.exec(normalised);
     if (driveMatch) {
         return pathModule.join(root, driveMatch[1].toUpperCase(), driveMatch[2]);
     }
     // UNC paths (\\server\share\... or //server/share/...) — normalise into 'unc' subdirectory.
-    const uncMatch = /^[\\/]{2}([^\\/]+)[\\/](.*)$/.exec(sourceAbsPath);
+    const uncMatch = /^[\\/]{2}([^\\/]+)[\\/](.*)$/.exec(normalised);
     if (uncMatch) {
         return pathModule.join(root, 'unc', uncMatch[1], uncMatch[2]);
     }
-    // POSIX-style absolute — strip the leading slash.
-    if (sourceAbsPath.startsWith('/')) {
-        return pathModule.join(root, sourceAbsPath.slice(1));
+    // POSIX-style absolute — strip ALL leading slashes so path.join stays under root.
+    if (normalised.startsWith('/')) {
+        return pathModule.join(root, normalised.replace(/^\/+/, ''));
     }
-    return pathModule.join(root, sourceAbsPath);
+    // Should not reach here due to isAbsolute check above, but kept as safety fallback.
+    return pathModule.join(root, normalised);
 }
 
 async function fileMtimeMs(filePath) {
@@ -71,13 +84,7 @@ async function transcodeOne(srcPath, dstPath) {
 }
 
 async function walkAndMirror(srcDir, dstDir) {
-    let entries;
-    try {
-        entries = await fs.promises.readdir(srcDir, { withFileTypes: true });
-    } catch (err) {
-        // Propagate so ensureUtf8Mirror can fall back to the source directory.
-        throw err;
-    }
+    const entries = await fs.promises.readdir(srcDir, { withFileTypes: true });
 
     // Prune stale mirror entries that no longer exist in the source.
     const srcNames = new Set(entries.map(e => e.name));
@@ -108,6 +115,8 @@ async function walkAndMirror(srcDir, dstDir) {
         const dstPath = pathModule.join(dstDir, entry.name);
 
         if (entry.isDirectory()) {
+            // Skip symlinked directories to prevent infinite recursion
+            if (entry.isSymbolicLink()) return;
             await walkAndMirror(srcPath, dstPath);
             return;
         }
@@ -159,7 +168,7 @@ async function ensureUtf8Mirror(sourceIncludeDir) {
     let promise = _mirrorPromises.get(mirrorDir);
     if (promise) return promise;
 
-    promise = _performMirror(sourceIncludeDir, mirrorDir, srcStat.mtimeMs);
+    promise = _performMirror(sourceIncludeDir, mirrorDir);
     _mirrorPromises.set(mirrorDir, promise);
     try {
         return await promise;
@@ -168,17 +177,13 @@ async function ensureUtf8Mirror(sourceIncludeDir) {
     }
 }
 
-async function _performMirror(sourceIncludeDir, mirrorDir, srcMtimeMs) {
+async function _performMirror(sourceIncludeDir, mirrorDir) {
     const stampPath = pathModule.join(mirrorDir, STAMP_FILE);
     try {
         await fs.promises.mkdir(mirrorDir, { recursive: true });
 
-        // Skip full walk if mirror was built after the source dir was last modified.
-        const stampMtime = await fileMtimeMs(stampPath);
-        if (stampMtime !== null && stampMtime >= srcMtimeMs) {
-            return mirrorDir;
-        }
-
+        // Always perform the full walk so nested-file changes are detected.
+        // Per-file mtime checks inside walkAndMirror skip up-to-date files.
         await walkAndMirror(sourceIncludeDir, mirrorDir);
         await fs.promises.writeFile(stampPath, '', 'utf8');
         return mirrorDir;

--- a/test/runUnitTests.js
+++ b/test/runUnitTests.js
@@ -28,6 +28,7 @@ mocha.addFile(path.resolve(__dirname, 'debugInstrumentation.test.js'));
 mocha.addFile(path.resolve(__dirname, 'debugFeatures.test.js'));
 mocha.addFile(path.resolve(__dirname, 'suite/logic.test.js'));
 mocha.addFile(path.resolve(__dirname, 'suite/extension.test.js'));
+mocha.addFile(path.resolve(__dirname, 'utf8Mirror.test.js'));
 
 // Run the tests
 mocha.run(failures => {

--- a/test/utf8Mirror.test.js
+++ b/test/utf8Mirror.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const assert = require('assert');
-const fs = require('fs');
-const os = require('os');
 const path = require('path');
 
 const { decodeTextBuffer } = require('../src/textDecoding');
@@ -56,8 +54,10 @@ suite('decodeTextBuffer', () => {
         // Place exactly 64 nulls — NOT greater than 64, so UTF-8 path
         for (let i = 0; i < 64; i++) buf[i * 2] = 0x00;
         const result = decodeTextBuffer(buf);
-        // utf8 decode — just verify it doesn't throw and returns a string
-        assert.strictEqual(typeof result, 'string');
+        // At exactly 64/256 nulls (not >25%), the heuristic keeps UTF-8 decoding.
+        // Verify the content survived as UTF-8 and was not misidentified as UTF-16.
+        assert.ok(result.includes('A'), 'UTF-8 decode should contain A chars');
+        assert.notStrictEqual(result, Buffer.from(buf).toString('utf16le'));
     });
 });
 
@@ -75,13 +75,16 @@ suite('mapToMirror', () => {
     }
 
     test('Windows path maps drive letter to segment', () => {
-        const result = withEnv('LOCALAPPDATA', 'C:\\Users\\user\\AppData\\Local', () => {
-            return mapToMirror('C:\\Users\\user\\AppData\\Roaming\\MetaQuotes\\Include');
-        });
-        assert.ok(result.includes(path.join('C', 'Users', 'user', 'AppData', 'Roaming', 'MetaQuotes', 'Include')));
+        if (process.platform !== 'win32') return; // path semantics are Windows-specific
+        const { result, root } = withEnv('LOCALAPPDATA', 'C:\\Users\\user\\AppData\\Local', () => ({
+            result: mapToMirror('C:\\Users\\user\\AppData\\Roaming\\MetaQuotes\\Include'),
+            root: getMirrorRoot()
+        }));
+        assert.strictEqual(result, path.join(root, 'C', 'Users', 'user', 'AppData', 'Roaming', 'MetaQuotes', 'Include'));
     });
 
     test('drive letter normalized to uppercase', () => {
+        if (process.platform !== 'win32') return; // path semantics are Windows-specific
         const lower = withEnv('LOCALAPPDATA', 'C:\\AppData\\Local', () => mapToMirror('c:\\foo\\bar'));
         const upper = withEnv('LOCALAPPDATA', 'C:\\AppData\\Local', () => mapToMirror('C:\\foo\\bar'));
         assert.strictEqual(lower, upper);
@@ -96,6 +99,7 @@ suite('mapToMirror', () => {
     });
 
     test('different drives produce different mirror paths', () => {
+        if (process.platform !== 'win32') return; // path semantics are Windows-specific
         const c = withEnv('LOCALAPPDATA', 'C:\\AppData\\Local', () => mapToMirror('C:\\Include'));
         const d = withEnv('LOCALAPPDATA', 'C:\\AppData\\Local', () => mapToMirror('D:\\Include'));
         assert.notStrictEqual(c, d);

--- a/test/utf8Mirror.test.js
+++ b/test/utf8Mirror.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { decodeTextBuffer } = require('../src/textDecoding');
+const { getMirrorRoot, mapToMirror } = require('../src/utf8Mirror');
+
+suite('decodeTextBuffer', () => {
+    test('empty buffer returns empty string', () => {
+        assert.strictEqual(decodeTextBuffer(Buffer.alloc(0)), '');
+    });
+
+    test('non-buffer returns empty string', () => {
+        assert.strictEqual(decodeTextBuffer(null), '');
+        assert.strictEqual(decodeTextBuffer('hello'), '');
+    });
+
+    test('plain UTF-8 decodes correctly', () => {
+        const buf = Buffer.from('hello world', 'utf8');
+        assert.strictEqual(decodeTextBuffer(buf), 'hello world');
+    });
+
+    test('UTF-16 LE with BOM decodes correctly', () => {
+        const text = 'hello';
+        const utf16 = Buffer.from(text, 'utf16le');
+        const bom = Buffer.from([0xff, 0xfe]);
+        const buf = Buffer.concat([bom, utf16]);
+        assert.strictEqual(decodeTextBuffer(buf), text);
+    });
+
+    test('UTF-16 LE without BOM detected by null-byte heuristic', () => {
+        // ASCII chars in UTF-16 LE have 0x00 as every second byte
+        const text = 'MQL5';
+        const buf = Buffer.from(text, 'utf16le');
+        // 4 chars × 2 bytes = 8 bytes; 4 null bytes = 50% → triggers heuristic
+        const result = decodeTextBuffer(buf);
+        assert.strictEqual(result, text);
+    });
+
+    test('UTF-8 with few null bytes not misdetected as UTF-16', () => {
+        // Build a 256-byte buffer with only 1 null byte (well below 25% threshold)
+        const data = Buffer.alloc(256, 0x41); // 'A' * 256
+        data[100] = 0x00; // 1 null byte out of 256 = 0.4%
+        const result = decodeTextBuffer(data);
+        assert.ok(result.length > 0);
+        // Should decode as UTF-8, not UTF-16
+        assert.strictEqual(result[0], 'A');
+    });
+
+    test('exactly at 25% null threshold — below triggers UTF-8', () => {
+        // sampleLength = 256, threshold = 256/4 = 64; need > 64 nulls for UTF-16
+        const buf = Buffer.alloc(256, 0x41);
+        // Place exactly 64 nulls — NOT greater than 64, so UTF-8 path
+        for (let i = 0; i < 64; i++) buf[i * 2] = 0x00;
+        const result = decodeTextBuffer(buf);
+        // utf8 decode — just verify it doesn't throw and returns a string
+        assert.strictEqual(typeof result, 'string');
+    });
+});
+
+suite('mapToMirror', () => {
+    function withEnv(key, value, fn) {
+        const original = process.env[key];
+        try {
+            if (value === undefined) delete process.env[key];
+            else process.env[key] = value;
+            return fn();
+        } finally {
+            if (original === undefined) delete process.env[key];
+            else process.env[key] = original;
+        }
+    }
+
+    test('Windows path maps drive letter to segment', () => {
+        const result = withEnv('LOCALAPPDATA', 'C:\\Users\\user\\AppData\\Local', () => {
+            return mapToMirror('C:\\Users\\user\\AppData\\Roaming\\MetaQuotes\\Include');
+        });
+        assert.ok(result.includes(path.join('C', 'Users', 'user', 'AppData', 'Roaming', 'MetaQuotes', 'Include')));
+    });
+
+    test('drive letter normalized to uppercase', () => {
+        const lower = withEnv('LOCALAPPDATA', 'C:\\AppData\\Local', () => mapToMirror('c:\\foo\\bar'));
+        const upper = withEnv('LOCALAPPDATA', 'C:\\AppData\\Local', () => mapToMirror('C:\\foo\\bar'));
+        assert.strictEqual(lower, upper);
+    });
+
+    test('POSIX path strips leading slash', () => {
+        const { result, root } = withEnv('LOCALAPPDATA', undefined, () => ({
+            result: mapToMirror('/usr/local/include'),
+            root: getMirrorRoot()
+        }));
+        assert.strictEqual(result, path.join(root, 'usr', 'local', 'include'));
+    });
+
+    test('different drives produce different mirror paths', () => {
+        const c = withEnv('LOCALAPPDATA', 'C:\\AppData\\Local', () => mapToMirror('C:\\Include'));
+        const d = withEnv('LOCALAPPDATA', 'C:\\AppData\\Local', () => mapToMirror('D:\\Include'));
+        assert.notStrictEqual(c, d);
+    });
+});


### PR DESCRIPTION
## Summary
This PR adds support for mirroring MetaQuotes include directories as UTF-8 to enable clangd to properly index library headers that are encoded in UTF-16 LE. MetaQuotes ships many MQL5 library headers (e.g., `Generic/`, `Expert/`) in UTF-16 LE format, which causes clangd to fail parsing them. The mirror is created on-demand and incrementally updated when configuration is generated.

## Key Changes

- **New module `src/textDecoding.js`**: Extracted and enhanced text decoding logic that auto-detects UTF-16 LE (with or without BOM) vs UTF-8 by sampling null bytes in the first 256 bytes of a file.

- **New module `src/utf8Mirror.js`**: Implements UTF-8 mirroring functionality:
  - `getMirrorRoot()`: Computes platform-specific mirror root (`%LOCALAPPDATA%/mql-clangd/mirror` on Windows, `~/.cache/mql-clangd/mirror` on POSIX)
  - `mapToMirror()`: Maps source paths to mirror paths, converting Windows drive letters to path segments for collision-free organization
  - `ensureUtf8Mirror()`: Recursively walks source include directories, transcodes `.mq4`, `.mq5`, and `.mqh` files to UTF-8, and caches based on modification times
  - Graceful fallback: returns original path on any failure so clangd continues working

- **Modified `src/createProperties.js`**: 
  - Integrated UTF-8 mirror into external include directory resolution
  - Added `UseUtf8Mirror` configuration option (enabled by default)
  - Routes external include paths through the mirror before passing to clangd

- **Modified `src/extension.js`**: 
  - Moved `decodeTextBuffer()` function to `src/textDecoding.js` for reuse across modules

- **Modified `package.json`**: 
  - Added `mql_tools.Clangd.UseUtf8Mirror` configuration option with documentation

## Implementation Details

- Mirror updates are incremental: files are only transcoded if the source is newer than the mirror copy
- The mirror respects the original directory structure for greppability
- Errors during mirroring are logged as warnings but don't block clangd from running
- The feature is enabled by default but can be disabled via configuration

https://claude.ai/code/session_01MpwHRWxf8X1KYrah6F3VZq