### PR TITLE
Strip comments before lightweight diagnostic regex checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Configurable TradeReportServer location**: New `mql_tools.Backtest.ServerDir` setting overrides the default `<MQL5 data folder>/Tools/TradeReportServer` location. Supports `${workspaceFolder}`, `~`, and relative paths. Resolved path is validated (`package.json` + `src/index.js`) before launch, with a clear error and a one-click action to open the setting when the package folder is missing.
 
 ### Bug Fixes
+- **Lightweight diagnostics false positives in comments**: The `mql-lightweight` checks for `assignment-in-condition` and `unnecessary-semicolon` no longer parse `=` or `};` characters inside line/block comments as code (fixes #39).
 - **Header Compilation Crash**: Fixed a critical `TypeError: a is not a function` error that occurred when compiling `.mqh` files. This was caused by a circular dependency in the extension's module loading (fixes #36).
 - **Legacy Compile Targets**: Automatically migrates legacy string-based compile targets to arrays to prevent `.map is not a function` errors when resolving header dependencies.
 - **Compile Target Type Guard**: `getCompileTargets` now validates the stored value type — arrays are returned as-is, legacy strings are wrapped, and any other unexpected type emits a console warning and returns `null` instead of silently producing a malformed value.

--- a/src/lightweightDiagnostics.js
+++ b/src/lightweightDiagnostics.js
@@ -43,7 +43,10 @@ function analyzeDocument(document) {
         let escaped = false;
         let quoteCount = 0;
         const hasLineContinuation = line.endsWith('\\');
-        let lineIsCode = !inBlockComment && !inMultiLineString;
+        // Lines that began inside a multi-line string are not analyzable as code
+        // (strings are not blanked in codeLine, so we'd otherwise treat string
+        // content as if it were source).
+        const lineStartedInMultilineString = inMultiLineString;
         let codeLine = '';
 
         for (let j = 0; j < line.length; j++) {
@@ -89,7 +92,7 @@ function analyzeDocument(document) {
                 }
                 // Character literal containing a double quote: skip '"'
                 if (char === '\'' && j + 2 < line.length && line[j + 1] === '"' && line[j + 2] === '\'') {
-                    codeLine += line.substr(j, 3);
+                    codeLine += line.substring(j, j + 3);
                     j += 2; // skip the '"' and closing '
                     continue;
                 }
@@ -119,14 +122,16 @@ function analyzeDocument(document) {
         }
 
         // --- Skip diagnostics for non-code lines ---
-        // If the entire line is inside a block comment or multi-line string
-        // that started before this line, skip diagnostic checks
-        if (!lineIsCode) continue;
-        // Skip empty lines and pure single-line comment lines
-        if (trimmed === '' || trimmed.startsWith('//')) continue;
+        // Lines wholly inside a multi-line string, or with no real code after
+        // comment-stripping (pure comment / blank / mid-block-comment lines),
+        // are not analyzable.
+        const codeTrimmed = codeLine.trim();
+        if (lineStartedInMultilineString || codeTrimmed === '') continue;
 
         // CHECK 1: Semicolon after closing brace (common typo, not struct/class/enum)
-        if (/\}\s*;/.test(codeLine) && !/^\s*(struct|class|enum)/.test(trimmed)) {
+        // The struct/class/enum guard runs on the comment-stripped line so
+        // leading comments like `/*...*/ struct Foo { ... };` are recognized.
+        if (/\}\s*;/.test(codeLine) && !/^(struct|class|enum)/.test(codeTrimmed)) {
             const m = codeLine.match(/\}\s*;/);
             const col = m.index + m[0].lastIndexOf(';');
             const diag = new vscode.Diagnostic(

--- a/src/lightweightDiagnostics.js
+++ b/src/lightweightDiagnostics.js
@@ -36,19 +36,24 @@ function analyzeDocument(document) {
         const trimmed = line.trim();
 
         // --- Character scanner: always runs to maintain state ---
-        // Tracks block comments, strings, char literals, and escape sequences
+        // Tracks block comments, strings, char literals, and escape sequences.
+        // Also builds `codeLine`: a copy of `line` with comment characters
+        // replaced by spaces, preserving column positions for diagnostic ranges.
         let inString = inMultiLineString;
         let escaped = false;
         let quoteCount = 0;
         const hasLineContinuation = line.endsWith('\\');
         let lineIsCode = !inBlockComment && !inMultiLineString;
+        let codeLine = '';
 
         for (let j = 0; j < line.length; j++) {
             const char = line[j];
 
             // Handle block comment state
             if (inBlockComment) {
+                codeLine += ' ';
                 if (char === '*' && j < line.length - 1 && line[j + 1] === '/') {
+                    codeLine += ' ';
                     inBlockComment = false;
                     j++; // skip the '/'
                 }
@@ -58,28 +63,33 @@ function analyzeDocument(document) {
             // Skip escaped characters inside strings
             if (escaped) {
                 escaped = false;
+                codeLine += char;
                 continue;
             }
 
             if (inString && char === '\\') {
                 escaped = true;
+                codeLine += char;
                 continue;
             }
 
             // Outside strings: detect comment starts
             if (!inString) {
-                // Single-line comment: stop scanning this line
+                // Single-line comment: blank out the rest of the line
                 if (char === '/' && j < line.length - 1 && line[j + 1] === '/') {
+                    codeLine += ' '.repeat(line.length - j);
                     break;
                 }
                 // Block comment start
                 if (char === '/' && j < line.length - 1 && line[j + 1] === '*') {
                     inBlockComment = true;
+                    codeLine += '  ';
                     j++; // skip the '*'
                     continue;
                 }
                 // Character literal containing a double quote: skip '"'
                 if (char === '\'' && j + 2 < line.length && line[j + 1] === '"' && line[j + 2] === '\'') {
+                    codeLine += line.substr(j, 3);
                     j += 2; // skip the '"' and closing '
                     continue;
                 }
@@ -97,6 +107,7 @@ function analyzeDocument(document) {
                     inString = false;
                 }
             }
+            codeLine += char;
         }
 
         // Update multi-line string state for next iteration
@@ -115,8 +126,8 @@ function analyzeDocument(document) {
         if (trimmed === '' || trimmed.startsWith('//')) continue;
 
         // CHECK 1: Semicolon after closing brace (common typo, not struct/class/enum)
-        if (/\}\s*;/.test(line) && !/^\s*(struct|class|enum)/.test(trimmed)) {
-            const m = line.match(/\}\s*;/);
+        if (/\}\s*;/.test(codeLine) && !/^\s*(struct|class|enum)/.test(trimmed)) {
+            const m = codeLine.match(/\}\s*;/);
             const col = m.index + m[0].lastIndexOf(';');
             const diag = new vscode.Diagnostic(
                 new vscode.Range(i, col, i, col + 1),
@@ -130,7 +141,7 @@ function analyzeDocument(document) {
 
         // CHECK 2: Assignment in condition (= instead of ==)
         // Skip intentional patterns like: if((x=expr)!=0) or if((x=func())!=NULL)
-        const conditionMatch = line.match(/\b(if|while)\s*\(\s*(.+)\s*\)(?:\s*\{|\s*$)/);
+        const conditionMatch = codeLine.match(/\b(if|while)\s*\(\s*(.+)\s*\)(?:\s*\{|\s*$)/);
         if (conditionMatch) {
             const condition = conditionMatch[2];
             // Remove string literals before checking for assignment
@@ -141,7 +152,7 @@ function analyzeDocument(document) {
             const hasComparison = /[=!<>]=|!=|==|<=|>=/.test(conditionNoStrings);
             // Simple assignment like if(x=5) but NOT if((x=5)!=0)
             if (hasAssignment && !hasComparison) {
-                const condStart = line.indexOf(conditionMatch[0]);
+                const condStart = codeLine.indexOf(conditionMatch[0]);
                 const diag = new vscode.Diagnostic(
                     new vscode.Range(i, condStart, i, condStart + conditionMatch[0].length),
                     'Possible assignment in condition (did you mean "==" instead of "="?)',

--- a/src/lightweightDiagnostics.js
+++ b/src/lightweightDiagnostics.js
@@ -305,4 +305,5 @@ function registerLightweightDiagnostics(context) {
 }
 
 // Export getter function instead of the collection itself
-module.exports = { registerLightweightDiagnostics, getLightweightDiagnostics };
+// analyzeDocument is exported for unit testing.
+module.exports = { registerLightweightDiagnostics, getLightweightDiagnostics, analyzeDocument };

--- a/test/lightweightDiagnostics.test.js
+++ b/test/lightweightDiagnostics.test.js
@@ -74,4 +74,37 @@ suite('lightweightDiagnostics — comment stripping (issue #39)', () => {
         const doc = makeDoc('/* this is\n  if (x = 5)\n  end */\nint y = 1;');
         assert.deepStrictEqual(codes(analyzeDocument(doc)), []);
     });
+
+    test('flags assignment-in-condition when a block comment closes earlier on the same line', () => {
+        // Regression: previously this whole line was skipped because the line
+        // began inside a block comment, so the trailing `if (x = 5)` slipped
+        // past the analyzer.
+        const doc = makeDoc('/* hdr */ if (x = 5)\n{\n}');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), ['assignment-in-condition']);
+    });
+
+    test('does not flag }; in struct preceded by a block comment', () => {
+        // Regression: the struct/class/enum guard now runs on the
+        // comment-stripped line so leading comments do not defeat it.
+        const doc = makeDoc('/* hdr */ struct Foo { int x; };');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), []);
+    });
+
+    test('does not flag escaped quotes inside a string in condition', () => {
+        const doc = makeDoc('if (s == "a \\"=\\" b")\n{\n}');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), []);
+    });
+
+    test('does not crash on an unterminated block comment at EOF', () => {
+        const doc = makeDoc('/* unterminated\n   if (x = 5)\n   no closer here');
+        // The scanner must not throw, and content inside the unterminated
+        // comment must not produce diagnostics.
+        const diags = analyzeDocument(doc);
+        assert.deepStrictEqual(codes(diags), []);
+    });
+
+    test('does not flag = inside an MQL char literal', () => {
+        const doc = makeDoc("if (delim == '=')\n{\n}");
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), []);
+    });
 });

--- a/test/lightweightDiagnostics.test.js
+++ b/test/lightweightDiagnostics.test.js
@@ -1,0 +1,77 @@
+const assert = require('assert');
+
+const { analyzeDocument } = require('../src/lightweightDiagnostics');
+
+function makeDoc(source, fileName = 'test.mq5') {
+    return {
+        getText: () => source,
+        fileName,
+        uri: `file:///${fileName}`,
+        positionAt: (offset) => {
+            const before = source.slice(0, offset);
+            const lines = before.split('\n');
+            return { line: lines.length - 1, character: lines[lines.length - 1].length };
+        }
+    };
+}
+
+function codes(diagnostics) {
+    return diagnostics.map(d => d.code).filter(Boolean);
+}
+
+suite('lightweightDiagnostics — comment stripping (issue #39)', () => {
+    test('does not flag = inside a line comment after if condition', () => {
+        const doc = makeDoc('if (TotalRecovery) // This is an = example (comment)\n{\n}');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), []);
+    });
+
+    test('still flags real assignment in condition', () => {
+        const doc = makeDoc('if (x = 5)\n{\n}');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), ['assignment-in-condition']);
+    });
+
+    test('does not flag intentional assignment paired with comparison', () => {
+        const doc = makeDoc('if ((x = func()) != 0)\n{\n}');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), []);
+    });
+
+    test('flags real assignment even when a == appears later in a comment', () => {
+        const doc = makeDoc('if (x = 5) // is == intended?\n{\n}');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), ['assignment-in-condition']);
+    });
+
+    test('does not flag = inside an inline block comment in condition', () => {
+        const doc = makeDoc('if (TotalRecovery /* x = 1 */)\n{\n}');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), []);
+    });
+
+    test('does not flag }; that appears inside a block comment', () => {
+        const doc = makeDoc('void f() { /* }; */ }');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), []);
+    });
+
+    test('still flags real }; at code level', () => {
+        const doc = makeDoc('int x = 5;\n};');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), ['unnecessary-semicolon']);
+    });
+
+    test('diagnostic range columns line up with the original line', () => {
+        const doc = makeDoc('if (x = 5) // = comment\n{\n}');
+        const diags = analyzeDocument(doc);
+        assert.strictEqual(diags.length, 1);
+        const r = diags[0].range;
+        assert.strictEqual(r.start.line, 0);
+        assert.strictEqual(r.start.character, 0);
+        assert.ok(r.end.character > r.start.character);
+    });
+
+    test('does not flag = inside a string literal in condition', () => {
+        const doc = makeDoc('if (s == "a = b")\n{\n}');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), []);
+    });
+
+    test('multi-line block comment spanning lines is fully ignored', () => {
+        const doc = makeDoc('/* this is\n  if (x = 5)\n  end */\nint y = 1;');
+        assert.deepStrictEqual(codes(analyzeDocument(doc)), []);
+    });
+});

--- a/test/mocks/vscode.js
+++ b/test/mocks/vscode.js
@@ -29,6 +29,14 @@ const DiagnosticSeverity = {
     Hint: 3
 };
 
+class Diagnostic {
+    constructor(range, message, severity) {
+        this.range = range;
+        this.message = message;
+        this.severity = severity;
+    }
+}
+
 const ConfigurationTarget = {
     Global: 1,
     Workspace: 2,
@@ -40,6 +48,7 @@ module.exports = {
     Position,
     RelativePattern,
     DiagnosticSeverity,
+    Diagnostic,
     ConfigurationTarget,
     env: {
         language: 'en'

--- a/test/runUnitTests.js
+++ b/test/runUnitTests.js
@@ -31,6 +31,7 @@ mocha.addFile(path.resolve(__dirname, 'suite/logic.test.js'));
 mocha.addFile(path.resolve(__dirname, 'suite/extension.test.js'));
 mocha.addFile(path.resolve(__dirname, 'utf8Mirror.test.js'));
 mocha.addFile(path.resolve(__dirname, 'utf8MirrorIntegration.test.js'));
+mocha.addFile(path.resolve(__dirname, 'lightweightDiagnostics.test.js'));
 
 // Run the tests
 mocha.run(failures => {


### PR DESCRIPTION
The lightweight `assignment-in-condition` and `unnecessary-semicolon`
checks ran their regexes against raw line text, so an `=` or `};` inside
a `//` or `/* */` comment could trigger false positives — e.g.
`if (TotalRecovery) // This is an = example` was flagged because the
greedy condition regex consumed the comment text.

The character scanner already tracks comment state for multi-line
bookkeeping; extend it to also build a `codeLine` mirror with comment
characters replaced by spaces (preserving column positions for
diagnostic ranges), and run CHECK 1 / CHECK 2 regexes against that.

Fixes #39.