### PR TITLE
feat(compile): post-compile-success VS Code task hook (refs #41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- **Post-compile task hook**: New `mql_tools.Compile.RunTaskOnSuccess` setting runs a named VS Code task (defined in `.vscode/tasks.json`) after every successful compile. Useful for triggering EA-reload workflows on Wine/macOS — e.g. write a flag file that an MT5 Service watches, so it can reload the freshly compiled EA via `ChartApplyTemplate()` without restarting the terminal. Task variables like `${fileBasenameNoExtension}` are resolved by VS Code against the active editor at task run time, so one task definition can serve all EAs. Leave the setting empty (default) to disable (refs #41).
+
 ## 1.1.44
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -165,6 +165,11 @@
                     "maximum": 300000,
                     "markdownDescription": "Timeout in milliseconds for Wine compilation processes. If a compilation takes longer than this, it will be terminated. Default: 60000 (60 seconds). Increase if you have complex projects that take longer to compile."
                 },
+                "mql_tools.Wine.RestartTerminalOnCompileSuccess": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "When running under Wine (macOS/Linux), automatically kill and relaunch the MetaTrader terminal after a successful compile so it picks up the new `.ex5`. Required because Wine's Win32 file-change notifications don't reliably propagate between MetaEditor and a running `terminal64.exe`. Only takes effect with the **Compile and Open Terminal** command. **Ignored on Windows and when `mql_tools.Wine.Enabled` is false.**"
+                },
                 "mql_tools.CompileTarget.Storage": {
                     "type": "string",
                     "enum": [

--- a/package.json
+++ b/package.json
@@ -170,6 +170,11 @@
                     "default": false,
                     "markdownDescription": "When running under Wine (macOS/Linux), automatically kill and relaunch the MetaTrader terminal after a successful compile so it picks up the new `.ex5`. Required because Wine's Win32 file-change notifications don't reliably propagate between MetaEditor and a running `terminal64.exe`. Only takes effect with the **Compile and Open Terminal** command. **Ignored on Windows and when `mql_tools.Wine.Enabled` is false.**"
                 },
+                "mql_tools.Compile.RunTaskOnSuccess": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Label of a VS Code task (defined in `.vscode/tasks.json`) to run after every successful compile. Leave empty to disable. Useful for triggering EA-reload workflows on Wine — e.g. write a flag file that an MQL5 Service inside MT5 watches, so it can reload the freshly compiled EA via `ChartApplyTemplate()`. Task variables like `${fileBasenameNoExtension}` are resolved by VS Code against the active editor at task run time."
+                },
                 "mql_tools.CompileTarget.Storage": {
                     "type": "string",
                     "enum": [

--- a/package.json
+++ b/package.json
@@ -165,11 +165,6 @@
                     "maximum": 300000,
                     "markdownDescription": "Timeout in milliseconds for Wine compilation processes. If a compilation takes longer than this, it will be terminated. Default: 60000 (60 seconds). Increase if you have complex projects that take longer to compile."
                 },
-                "mql_tools.Wine.RestartTerminalOnCompileSuccess": {
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "When running under Wine (macOS/Linux), automatically kill and relaunch the MetaTrader terminal after a successful compile so it picks up the new `.ex5`. Required because Wine's Win32 file-change notifications don't reliably propagate between MetaEditor and a running `terminal64.exe`. Only takes effect with the **Compile and Open Terminal** command. **Ignored on Windows and when `mql_tools.Wine.Enabled` is false.**"
-                },
                 "mql_tools.Compile.RunTaskOnSuccess": {
                     "type": "string",
                     "default": "",

--- a/src/contextMenu.js
+++ b/src/contextMenu.js
@@ -330,33 +330,6 @@ function _killTerminal(exeName) {
     });
 }
 
-/** Check if a Wine terminal process is running via host pgrep. */
-function _isTerminalRunningWine(exeName) {
-    return new Promise(resolve => {
-        if (!/^[A-Za-z0-9._-]+$/.test(exeName)) {
-            resolve(false);
-            return;
-        }
-        // -f matches the full argv ("...terminal64.exe ..."); Wine's host-side
-        // process is wine64-preloader or similar, so a plain image match fails.
-        childProcess.execFile('pgrep', ['-f', exeName], { timeout: 3000 }, (err) => {
-            // pgrep exits 0 when matched, 1 when not, >1 on error
-            resolve(!err);
-        });
-    });
-}
-
-/** Kill a running Wine terminal process via host pkill. */
-function _killTerminalWine(exeName) {
-    return new Promise(resolve => {
-        if (!/^[A-Za-z0-9._-]+$/.test(exeName)) {
-            resolve();
-            return;
-        }
-        childProcess.execFile('pkill', ['-f', exeName], { timeout: 5000 }, () => resolve());
-    });
-}
-
 /**
  * Build a startup INI file so MetaTrader auto-attaches an EA on launch.
  *
@@ -505,18 +478,6 @@ async function OpenTradingTerminal(eaPath, mql5Root) {
                     // User chose manual attach or dismissed — skip INI
                     iniPath = null;
                 }
-            }
-        } else if (config.Wine && config.Wine.RestartTerminalOnCompileSuccess) {
-            // Wine's Win32 file-change notifications don't reliably propagate
-            // between MetaEditor and a running terminal64.exe, so MT5 never sees
-            // the freshly compiled .ex5. When the user opts in, kill the running
-            // terminal so the relaunch below picks up the new build (and /config:
-            // is honored on the fresh launch).
-            const running = await _isTerminalRunningWine(lowNm);
-            if (running) {
-                _oc.appendLine(`[Auto-attach] Wine: killing running ${lowNm} to pick up new build.`);
-                await _killTerminalWine(lowNm);
-                await new Promise(r => setTimeout(r, TERMINAL_KILL_DELAY_MS));
             }
         }
     } else if (eaPath) {

--- a/src/contextMenu.js
+++ b/src/contextMenu.js
@@ -330,6 +330,33 @@ function _killTerminal(exeName) {
     });
 }
 
+/** Check if a Wine terminal process is running via host pgrep. */
+function _isTerminalRunningWine(exeName) {
+    return new Promise(resolve => {
+        if (!/^[A-Za-z0-9._-]+$/.test(exeName)) {
+            resolve(false);
+            return;
+        }
+        // -f matches the full argv ("...terminal64.exe ..."); Wine's host-side
+        // process is wine64-preloader or similar, so a plain image match fails.
+        childProcess.execFile('pgrep', ['-f', exeName], { timeout: 3000 }, (err) => {
+            // pgrep exits 0 when matched, 1 when not, >1 on error
+            resolve(!err);
+        });
+    });
+}
+
+/** Kill a running Wine terminal process via host pkill. */
+function _killTerminalWine(exeName) {
+    return new Promise(resolve => {
+        if (!/^[A-Za-z0-9._-]+$/.test(exeName)) {
+            resolve();
+            return;
+        }
+        childProcess.execFile('pkill', ['-f', exeName], { timeout: 5000 }, () => resolve());
+    });
+}
+
 /**
  * Build a startup INI file so MetaTrader auto-attaches an EA on launch.
  *
@@ -478,6 +505,18 @@ async function OpenTradingTerminal(eaPath, mql5Root) {
                     // User chose manual attach or dismissed — skip INI
                     iniPath = null;
                 }
+            }
+        } else if (config.Wine && config.Wine.RestartTerminalOnCompileSuccess) {
+            // Wine's Win32 file-change notifications don't reliably propagate
+            // between MetaEditor and a running terminal64.exe, so MT5 never sees
+            // the freshly compiled .ex5. When the user opts in, kill the running
+            // terminal so the relaunch below picks up the new build (and /config:
+            // is honored on the fresh launch).
+            const running = await _isTerminalRunningWine(lowNm);
+            if (running) {
+                _oc.appendLine(`[Auto-attach] Wine: killing running ${lowNm} to pick up new build.`);
+                await _killTerminalWine(lowNm);
+                await new Promise(r => setTimeout(r, TERMINAL_KILL_DELAY_MS));
             }
         }
     } else if (eaPath) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -758,6 +758,23 @@ async function runCompileSuccessAction(options = {}, logger = console) {
     }
 }
 
+function shouldRunConfiguredPostCompileTask(hasErrors, config) {
+    if (hasErrors) return false;
+    const cfg = config || vscode.workspace.getConfiguration('mql_tools');
+    const taskLabel = cfg.get('Compile.RunTaskOnSuccess');
+    return typeof taskLabel === 'string' && taskLabel.trim().length > 0;
+}
+
+async function runConfiguredPostCompileTask(logger = console) {
+    const taskLabel = (vscode.workspace.getConfiguration('mql_tools').get('Compile.RunTaskOnSuccess') || '').trim();
+    if (!taskLabel) return;
+    try {
+        await vscode.commands.executeCommand('workbench.action.tasks.runTask', taskLabel);
+    } catch (error) {
+        logger.error(`Compile succeeded, but the post-compile task "${taskLabel}" failed to start:`, error);
+    }
+}
+
 /**
  * Resolve which paths to compile for a .mqh header file.
  *
@@ -911,6 +928,9 @@ async function Compile(rt, context, options = {}) {
 
     if (shouldRunCompileSuccessAction(hasErrors, options)) {
         await runCompileSuccessAction(options);
+    }
+    if (shouldRunConfiguredPostCompileTask(hasErrors)) {
+        await runConfiguredPostCompileTask();
     }
 }
 
@@ -3068,6 +3088,8 @@ module.exports = {
     shouldFocusProblemsPanel,
     shouldRunCompileSuccessAction,
     runCompileSuccessAction,
+    shouldRunConfiguredPostCompileTask,
+    runConfiguredPostCompileTask,
     resolveHeaderCompilePlan,
     inferMqlDataDirFromPath
 };


### PR DESCRIPTION
Addresses #41 — "Unable to trigger refresh of EA after successful compile (OSX / Wine)".

## Why

On Windows, MT5 auto-reloads an attached EA when its `.ex5` changes on disk. Under Wine on macOS the Win32 directory-change notifications don't reliably propagate between MetaEditor and a running `terminal64.exe`, so MT5 never sees the new binary and keeps running the old code.

## What

Adds **`mql_tools.Compile.RunTaskOnSuccess`** (string, default `""`).

When set to a task label, runs that VS Code task (defined in `.vscode/tasks.json`) via `workbench.action.tasks.runTask` after every successful compile. Enables the EA-reload workflow [proposed by @strongland](https://github.com/pungggi/MQL_clangd/issues/41#issuecomment-4492533121):

- VS Code task writes a flag file under `MQL5/Files/COMPILEFLAGS/`
- An always-on MQL5 Service inside MT5 watches the folder and reloads the matching EA via `ChartApplyTemplate()`

Task variables (`${fileBasenameNoExtension}`, etc.) are resolved by VS Code against the active editor at task run time, so a single task definition can serve all EAs. Works the same on Windows and Wine.

## Files

- `package.json` — one new setting under the existing `Compile.*` namespace.
- `src/extension.js` — adds `shouldRunConfiguredPostCompileTask` / `runConfiguredPostCompileTask`, called from `Compile()` after the existing `runCompileSuccessAction`. Errors from the task launcher are logged but never block the compile flow.

## Commits

`36cc010` (terminal kill+relaunch opt-in) and its revert `259b813` are kept in history for context — the net change is just the single commit `0b44703`. Happy to squash on merge.

## Test plan

- [ ] Plain `Compile` with `Compile.RunTaskOnSuccess` set to a valid task label — task runs after successful compile
- [ ] Same with a compile error — task does **not** run
- [ ] Empty / whitespace-only label — no-op, no errors logged
- [ ] Non-existent task label — error logged, compile result unaffected
- [ ] End-to-end on Wine/macOS: task writes flag file → MT5 Service detects it → EA reloads via `ChartApplyTemplate()`

https://claude.ai/code/session_01E44Fp6FmrLDL5SjdXsS1PR