### PR TITLE
fix: break circular require crashing .mqh compile target resolver (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+- **Header Compilation Crash (regression)**: Fixed `a.detectWorkspaceMqlVersion is not a function` thrown when compiling `.mqh` files. A circular `require` between `compileTargetResolver.js` and `createProperties.js` left the resolver holding a stale empty exports reference; the call site now lazy-loads `createProperties` to break the cycle (fixes #42).
+
 ## 1.1.44
 
 ### Bug Fixes

--- a/src/compileTargetResolver.js
+++ b/src/compileTargetResolver.js
@@ -2,7 +2,7 @@
 const vscode = require('vscode');
 const fs = require('fs');
 const pathModule = require('path');
-const createProperties = require('./createProperties');
+// createProperties is required lazily inside buildReverseIndex to avoid a circular-require cycle that captures a stale empty exports reference.
 
 /**
  * Compile Target Resolver
@@ -78,6 +78,7 @@ async function buildReverseIndex(workspaceFolder, include4Dir, include5Dir, maxF
     );
 
     // Determine workspace MQL version from scanned files
+    const createProperties = require('./createProperties');
     const workspaceVersion = createProperties.detectWorkspaceMqlVersion(files, workspaceRoot, workspaceFolder.name);
 
     for (const fileUri of files) {


### PR DESCRIPTION
Top-level require('./createProperties') in compileTargetResolver formed a
cycle with createProperties.js. Because both files reassign module.exports,
the load-order extension.js uses (createProperties before
compileTargetResolver) leaves the latter holding a stale empty {} reference.
The error surfaced only on .mqh compiles — non-.mqh paths early-return
before reaching buildReverseIndex — as the minified
"a.detectWorkspaceMqlVersion is not a function".

Lazy-load createProperties inside buildReverseIndex (its sole call site)
to break the cycle.