### PR TITLE
MT5 Service that listens to vscode EA compilation changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# Changelog
+## 1.1.46
 
-## Unreleased
+### Features
+- **CompileListenerService for MT5**: New companion service `files/CompileListenerService.mq5` (true `#property service` with `OnStart`/`Sleep` loop, runs independently of charts). Polls `MQL5/Files/COMPILEFLAGS/<EA>.flag` once per second, deletes the flag, locates the chart running the named EA, and calls `ChartApplyTemplate("<EA>.tpl")` to reload it. Configure via the `expertNames` input (comma-separated; whitespace trimmed) and `showDebugOutput`. Pairs with the post-compile task hook above to close the Wine/macOS reload gap (refs #41, #45).
+
+## 1.1.45
 
 ### Features
 - **Post-compile task hook**: New `mql_tools.Compile.RunTaskOnSuccess` setting runs a named VS Code task (defined in `.vscode/tasks.json`) after every successful compile. Useful for triggering EA-reload workflows on Wine/macOS — e.g. write a flag file that an MT5 Service watches, so it can reload the freshly compiled EA via `ChartApplyTemplate()` without restarting the terminal. Task variables like `${fileBasenameNoExtension}` are resolved by VS Code against the active editor at task run time, so one task definition can serve all EAs. Leave the setting empty (default) to disable (refs #41).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Quick Setup Guide](#quick-setup-guide)
 - [Important Notes](#important-notes)
 - [MetaEditor on macOS / Linux (Wine)](#metaeditor-on-macos--linux-wine)
+- [Auto-Reload EA After Compile (MT5 Service)](#auto-reload-ea-after-compile-mt5-service)
 - [Live Runtime Log](#live-runtime-log)
 - [Trade Report Dashboard](#trade-report-dashboard)
 - [Run Backtest](#run-backtest)
@@ -158,6 +159,35 @@ When `mql_tools.Wine.Enabled` is `true` on macOS/Linux:
 - Compile / Check commands run MetaEditor via Wine instead of executing the `.exe` directly.
 - Paths for source files, include directories and logs are automatically converted with `winepath -w`, so MetaEditor sees them as `Z:\\...` paths.
 - Behaviour on Windows is unchanged (the wrapper is ignored on Windows, or when `Wine.Enabled` is `false`).
+
+---
+
+### Auto-Reload EA After Compile (MT5 Service)
+
+On Wine/macOS (and any setup where MetaTrader doesn't auto-reload the running EA after compile) you can close the loop with a tiny MT5 Service that watches for flag files written by the post-compile task hook.
+
+A ready-to-use service ships under [`files/CompileListenerService.mq5`](files/CompileListenerService.mq5). Drop it into `MQL5/Services/`, compile, then start it from **Navigator → Services**.
+
+**How it works**
+
+1. The extension's post-compile task hook (`mql_tools.Compile.RunTaskOnSuccess`) runs a VS Code task after a successful compile. Configure that task to write a flag file, e.g. `MQL5/Files/COMPILEFLAGS/<EA>.flag`.
+2. `CompileListenerService.mq5` polls the `COMPILEFLAGS` folder once per second. When `<EA>.flag` appears it:
+   - deletes the flag file,
+   - finds the chart whose `CHART_EXPERT_NAME` matches `<EA>`,
+   - calls `ChartApplyTemplate(chartId, "<EA>.tpl")` — which reloads the EA from the named template.
+
+**Service inputs**
+
+| Input | Default | Purpose |
+|-------|---------|---------|
+| `expertNames` | `"EA_Name_1,EA_Name_2"` | Comma-separated EA names to watch (no extension). Whitespace around names is trimmed. |
+| `showDebugOutput` | `true` | Print per-chart scan info and "applying template" lines to the Experts log. |
+
+**Notes**
+
+- It is a real MT5 service (`#property service` + `OnStart`), so it runs independently of any chart and survives terminal reload.
+- For each EA, save a template named `<EA>.tpl` in `MQL5/Profiles/Templates/`. The service applies that template on reload.
+- Failures from `FileDelete` and `ChartApplyTemplate` are always logged with `GetLastError()` so silent retry loops are easy to spot.
 
 ---
 

--- a/files/CompileListenerService.mq5
+++ b/files/CompileListenerService.mq5
@@ -1,66 +1,28 @@
 //==============================================================================
 // MT5 Service that looks for the existence of a file with the same
-// name as the EA. If the post-compile vscode task is configured and
-// the file is created, the service will detect it and reapply a 
+// name as the EA. If the post-compile VS Code task is configured and
+// the file is created, the service will detect it and reapply a
 // chart template with the same name as the EA.
 //
-// Usage: Compile and drag the Service to a new chart.chartId
+// Usage: Compile, then start the Service from the Navigator (Services).
 // Enable debug logging initially to verify that it works.
 //==============================================================================
+
+#property service
+#property version   "1.00"
 
 
 //==============================================================================
 // SETTINGS
 //==============================================================================
-input string expertNames   = "EA_Name_1,EA_Name_2";    // Comma-separated EA names, without ".tpl"
-input bool showDebugOuput  = true;                    // Show debut ouput in the Experts log
+input string expertNames      = "EA_Name_1,EA_Name_2";   // Comma-separated EA names, without ".tpl"
+input bool   showDebugOutput  = true;                    // Show debug output in the Experts log
 
 
 //==============================================================================
 // VARIABLES
 //==============================================================================
-string expertNamesArray[];      
-
-
-//==============================================================================
-// INITIALISATION
-//==============================================================================
-int OnInit() {
-
-   if (expertNames == "") { Print("Expert name(s) configuration missing."); }
-   else {
-   
-      StringSplit(expertNames, ',', expertNamesArray); 
-      EventSetTimer(1);
-   }
-
-   return INIT_SUCCEEDED;
-}
-
-//==============================================================================
-// COMPILE WATCHER LOOP
-//==============================================================================
-void OnTimer() {
-
-   for (uint i = 0; i < expertNamesArray.Size(); i++) {
-            
-      string filePath = "COMPILEFLAGS\\" + expertNamesArray[i] + ".flag";
-      int handle = FileOpen(filePath, FILE_READ|FILE_TXT);
-
-      if(handle == INVALID_HANDLE) { continue; }
-      else {
-         FileClose(handle);   
-         FileDelete(filePath);
-         
-         long chartId = IsExpertAdvisorOnChart(expertNamesArray[i]);
-         
-         if (chartId != -1) {
-            if (showDebugOuput) { Print("FOUND EA " + expertNamesArray[i] + " on chart " + (string)chartId + ", applying template " + expertNamesArray[i] + ".tpl"); }
-            ChartApplyTemplate(chartId, expertNamesArray[i] + ".tpl"); 
-         }
-      }
-   }
-}
+string expertNamesArray[];
 
 
 //==============================================================================
@@ -69,16 +31,75 @@ void OnTimer() {
 long IsExpertAdvisorOnChart(string expertNameWanted) {
 
    long chartId = ChartFirst();
-   
+
    while(chartId >= 0) {
-   
+
       string expertNameFound = ChartGetString(chartId, CHART_EXPERT_NAME);
-            
-      if (showDebugOuput) { Print("CHART INFORMATION:  ChartId=", chartId, " Symbol=", ChartSymbol(chartId), " Expert=", expertNameFound); }
-      
+
+      if (showDebugOutput) { Print("CHART INFORMATION:  ChartId=", chartId, " Symbol=", ChartSymbol(chartId), " Expert=", expertNameFound); }
+
       if (expertNameFound == expertNameWanted) { return chartId; }
       else { chartId = ChartNext(chartId); }
    }
-   
+
    return -1;
+}
+
+
+//==============================================================================
+// COMPILE WATCHER TICK
+//==============================================================================
+void CheckCompileFlags() {
+
+   for (int i = 0; i < ArraySize(expertNamesArray); i++) {
+
+      string name = expertNamesArray[i];
+      if (name == "") { continue; }
+
+      string filePath = "COMPILEFLAGS\\" + name + ".flag";
+      int handle = FileOpen(filePath, FILE_READ|FILE_TXT);
+
+      if (handle == INVALID_HANDLE) { continue; }
+
+      FileClose(handle);
+
+      if (!FileDelete(filePath)) {
+         Print("Failed to delete flag ", filePath, " error=", GetLastError());
+         continue;
+      }
+
+      long chartId = IsExpertAdvisorOnChart(name);
+      if (chartId == -1) {
+         if (showDebugOutput) { Print("EA ", name, " not found on any chart, skipping template apply."); }
+         continue;
+      }
+
+      if (showDebugOutput) { Print("FOUND EA ", name, " on chart ", chartId, ", applying template ", name, ".tpl"); }
+      if (!ChartApplyTemplate(chartId, name + ".tpl")) {
+         Print("ChartApplyTemplate failed for ", name, " on chart ", chartId, " error=", GetLastError());
+      }
+   }
+}
+
+
+//==============================================================================
+// SERVICE ENTRY POINT
+//==============================================================================
+void OnStart() {
+
+   if (expertNames == "") {
+      Print("Expert name(s) configuration missing.");
+      return;
+   }
+
+   StringSplit(expertNames, ',', expertNamesArray);
+
+   for (int i = 0; i < ArraySize(expertNamesArray); i++) {
+      expertNamesArray[i] = StringTrimLeft(StringTrimRight(expertNamesArray[i]));
+   }
+
+   while (!IsStopped()) {
+      CheckCompileFlags();
+      Sleep(1000);
+   }
 }

--- a/files/CompileListenerService.mq5
+++ b/files/CompileListenerService.mq5
@@ -1,0 +1,84 @@
+//==============================================================================
+// MT5 Service that looks for the existence of a file with the same
+// name as the EA. If the post-compile vscode task is configured and
+// the file is created, the service will detect it and reapply a 
+// chart template with the same name as the EA.
+//
+// Usage: Compile and drag the Service to a new chart.chartId
+// Enable debug logging initially to verify that it works.
+//==============================================================================
+
+
+//==============================================================================
+// SETTINGS
+//==============================================================================
+input string expertNames   = "EA_Name_1,EA_Name_2";    // Comma-separated EA names, without ".tpl"
+input bool showDebugOuput  = true;                    // Show debut ouput in the Experts log
+
+
+//==============================================================================
+// VARIABLES
+//==============================================================================
+string expertNamesArray[];      
+
+
+//==============================================================================
+// INITIALISATION
+//==============================================================================
+int OnInit() {
+
+   if (expertNames == "") { Print("Expert name(s) configuration missing."); }
+   else {
+   
+      StringSplit(expertNames, ',', expertNamesArray); 
+      EventSetTimer(1);
+   }
+
+   return INIT_SUCCEEDED;
+}
+
+//==============================================================================
+// COMPILE WATCHER LOOP
+//==============================================================================
+void OnTimer() {
+
+   for (uint i = 0; i < expertNamesArray.Size(); i++) {
+            
+      string filePath = "COMPILEFLAGS\\" + expertNamesArray[i] + ".flag";
+      int handle = FileOpen(filePath, FILE_READ|FILE_TXT);
+
+      if(handle == INVALID_HANDLE) { continue; }
+      else {
+         FileClose(handle);   
+         FileDelete(filePath);
+         
+         long chartId = IsExpertAdvisorOnChart(expertNamesArray[i]);
+         
+         if (chartId != -1) {
+            if (showDebugOuput) { Print("FOUND EA " + expertNamesArray[i] + " on chart " + (string)chartId + ", applying template " + expertNamesArray[i] + ".tpl"); }
+            ChartApplyTemplate(chartId, expertNamesArray[i] + ".tpl"); 
+         }
+      }
+   }
+}
+
+
+//==============================================================================
+// FIND AN EA AMONGST CURRENTLY OPEN CHARTS FROM EA NAME
+//==============================================================================
+long IsExpertAdvisorOnChart(string expertNameWanted) {
+
+   long chartId = ChartFirst();
+   
+   while(chartId >= 0) {
+   
+      string expertNameFound = ChartGetString(chartId, CHART_EXPERT_NAME);
+            
+      if (showDebugOuput) { Print("CHART INFORMATION:  ChartId=", chartId, " Symbol=", ChartSymbol(chartId), " Expert=", expertNameFound); }
+      
+      if (expertNameFound == expertNameWanted) { return chartId; }
+      else { chartId = ChartNext(chartId); }
+   }
+   
+   return -1;
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mql-clangd",
     "displayName": "MQL Clangd",
     "description": "High-performance MQL4/MQL5 tools with Clangd support.",
-    "version": "1.1.44",
+    "version": "1.1.45",
     "publisher": "ngsoftware",
     "engines": {
         "vscode": "^1.90.0",


### PR DESCRIPTION
MT5 Service that looks for the existence of a file with the same
name as the EA. If the post-compile vscode task is configured and
the file is created, the service will detect it and reapply a 
chart template with the same name as the EA.

Usage: Compile and drag the Service to a new chart.chartId
Enable debug logging initially to verify that it works.