### PR TITLE
Backtest: accept YYYYMMDD date input and normalize to YYYY.MM.DD

### DIFF
--- a/src/backtestRunner.js
+++ b/src/backtestRunner.js
@@ -40,8 +40,15 @@ const DEFAULT_TERMINAL_PATHS = [
 // Date helpers
 // ---------------------------------------------------------------------------
 
-// Accepts the canonical dotted form `YYYY.MM.DD` and the compact `YYYYMMDD`
-// form used in MT5 tester INI filenames (users often copy-paste from there).
+/**
+ * Parse an MQL date string into a local `Date`, validating it calendrically.
+ *
+ * Accepts the canonical dotted form `YYYY.MM.DD` and the compact `YYYYMMDD`
+ * form used in MT5 tester INI filenames (users often copy-paste from there).
+ *
+ * @param {*} v - The raw date string.
+ * @returns {Date|null} The parsed Date, or null if the input is malformed or not a real calendar date.
+ */
 function parseMqlDate(v) {
     if (typeof v !== 'string') return null;
 
@@ -59,6 +66,12 @@ function parseMqlDate(v) {
     return d;
 }
 
+/**
+ * Report whether a string is a valid MQL date in either accepted format.
+ *
+ * @param {*} v - The raw date string.
+ * @returns {boolean} True if `v` parses to a real calendar date.
+ */
 function isValidDate(v) {
     return parseMqlDate(v) !== null;
 }

--- a/src/backtestRunner.js
+++ b/src/backtestRunner.js
@@ -40,9 +40,20 @@ const DEFAULT_TERMINAL_PATHS = [
 // Date helpers
 // ---------------------------------------------------------------------------
 
+// Accepts the canonical dotted form `YYYY.MM.DD` and the compact `YYYYMMDD`
+// form used in MT5 tester INI filenames (users often copy-paste from there).
 function parseMqlDate(v) {
-    if (!/^\d{4}\.\d{2}\.\d{2}$/.test(v)) return null;
-    const [year, month, day] = v.split('.').map(Number);
+    if (typeof v !== 'string') return null;
+
+    let year, month, day;
+    if (/^\d{4}\.\d{2}\.\d{2}$/.test(v)) {
+        [year, month, day] = v.split('.').map(Number);
+    } else if (/^\d{8}$/.test(v)) {
+        [year, month, day] = [v.slice(0, 4), v.slice(4, 6), v.slice(6, 8)].map(Number);
+    } else {
+        return null;
+    }
+
     const d = new Date(year, month - 1, day);
     if (d.getFullYear() !== year || d.getMonth() !== month - 1 || d.getDate() !== day) return null;
     return d;
@@ -158,18 +169,18 @@ async function getTestParameters(mql5Root, eaName) {
     if (symbol === null) return null;
 
     const fromDate = await vscode.window.showInputBox({
-        prompt: 'From date (YYYY.MM.DD)',
+        prompt: 'From date (YYYY.MM.DD or YYYYMMDD)',
         value: defaults.fromDate,
         title: 'MQL Backtest: Start Date',
-        validateInput: v => isValidDate(v) ? null : 'Invalid date (YYYY.MM.DD)',
+        validateInput: v => isValidDate(v) ? null : 'Invalid date (YYYY.MM.DD or YYYYMMDD)',
     });
     if (fromDate === undefined) return null;
 
     const toDate = await vscode.window.showInputBox({
-        prompt: 'To date (YYYY.MM.DD)',
+        prompt: 'To date (YYYY.MM.DD or YYYYMMDD)',
         value: defaults.toDate,
         title: 'MQL Backtest: End Date',
-        validateInput: v => isValidDate(v) ? null : 'Invalid date (YYYY.MM.DD)',
+        validateInput: v => isValidDate(v) ? null : 'Invalid date (YYYY.MM.DD or YYYYMMDD)',
     });
     if (toDate === undefined) return null;
 

--- a/src/backtestRunner.js
+++ b/src/backtestRunner.js
@@ -236,7 +236,7 @@ function getSilentParameters(mql5Root, eaName) {
         return null;
     }
     if (!isValidDate(defaults.fromDate) || !isValidDate(defaults.toDate)) {
-        vscode.window.showErrorMessage(`tester.ini for ${eaName} contains invalid dates (expected YYYY.MM.DD).`);
+        vscode.window.showErrorMessage(`tester.ini for ${eaName} contains invalid dates (expected YYYY.MM.DD or YYYYMMDD).`);
         return null;
     }
     return defaults;

--- a/src/backtestService.js
+++ b/src/backtestService.js
@@ -191,11 +191,17 @@ function updateTesterIniContent(content, params, lineEnding) {
     return result.join(detectedEnding);
 }
 
+// MT5 only accepts the dotted `YYYY.MM.DD` form in tester.ini. Inputs may arrive
+// in the compact `YYYYMMDD` form (copied from tester INI filenames), so normalize.
+function normalizeMqlDate(v) {
+    return /^\d{8}$/.test(v) ? `${v.slice(0, 4)}.${v.slice(4, 6)}.${v.slice(6, 8)}` : v;
+}
+
 function getTesterIniReplacement(section, key, oldValue, params) {
     if (section === 'tester') {
         if (key === 'Symbol' && params.symbol) return `Symbol=${params.symbol}`;
-        if (key === 'FromDate' && params.fromDate) return `FromDate=${params.fromDate}`;
-        if (key === 'ToDate' && params.toDate) return `ToDate=${params.toDate}`;
+        if (key === 'FromDate' && params.fromDate) return `FromDate=${normalizeMqlDate(params.fromDate)}`;
+        if (key === 'ToDate' && params.toDate) return `ToDate=${normalizeMqlDate(params.toDate)}`;
     }
 
     if (section === 'inputs' && key === 'RiskPercentage' && params.riskPercentage !== undefined) {

--- a/src/backtestService.js
+++ b/src/backtestService.js
@@ -191,12 +191,31 @@ function updateTesterIniContent(content, params, lineEnding) {
     return result.join(detectedEnding);
 }
 
-// MT5 only accepts the dotted `YYYY.MM.DD` form in tester.ini. Inputs may arrive
-// in the compact `YYYYMMDD` form (copied from tester INI filenames), so normalize.
+/**
+ * Normalize a date value to the dotted `YYYY.MM.DD` form MT5 requires in tester.ini.
+ *
+ * Inputs may arrive in the compact `YYYYMMDD` form (copied from tester INI
+ * filenames). Non-string values (and any other format) are returned unchanged,
+ * so a numeric date in `params` can't trigger a TypeError on `.slice()`.
+ *
+ * @param {*} v - The raw date value.
+ * @returns {*} The dotted-form string for compact input; otherwise `v` unchanged.
+ */
 function normalizeMqlDate(v) {
-    return /^\d{8}$/.test(v) ? `${v.slice(0, 4)}.${v.slice(4, 6)}.${v.slice(6, 8)}` : v;
+    if (typeof v !== 'string' || !/^\d{8}$/.test(v)) return v;
+    return `${v.slice(0, 4)}.${v.slice(4, 6)}.${v.slice(6, 8)}`;
 }
 
+/**
+ * Build the replacement line for a single tester.ini `key=value` entry, or null
+ * when the entry should be left untouched.
+ *
+ * @param {string} section - The current INI section name (e.g. `tester`, `inputs`).
+ * @param {string} key - The setting key on the current line.
+ * @param {string} oldValue - The existing value (right of `=`), used to preserve format.
+ * @param {object} params - Backtest parameters (symbol, fromDate, toDate, riskPercentage).
+ * @returns {string|null} The replacement line, or null to keep the original.
+ */
 function getTesterIniReplacement(section, key, oldValue, params) {
     if (section === 'tester') {
         if (key === 'Symbol' && params.symbol) return `Symbol=${params.symbol}`;

--- a/test/backtestRunner.test.js
+++ b/test/backtestRunner.test.js
@@ -44,4 +44,21 @@ suite('backtestRunner — internal runner helpers', function () {
         assert.strictEqual(parseMqlDate('2025.13.01'), null);
         assert.strictEqual(parseMqlDate('2025.02.30'), null);
     });
+
+    test('accepts the compact YYYYMMDD form from tester INI filenames', function () {
+        assert.ok(isValidDate('20260201'));
+        assert.ok(isValidDate('20240229'));
+
+        const parsed = parseMqlDate('20260201');
+        assert.strictEqual(parsed.getFullYear(), 2026);
+        assert.strictEqual(parsed.getMonth(), 1);
+        assert.strictEqual(parsed.getDate(), 1);
+    });
+
+    test('rejects calendrically invalid compact dates', function () {
+        assert.strictEqual(isValidDate('20250229'), false);
+        assert.strictEqual(isValidDate('20251301'), false);
+        assert.strictEqual(isValidDate('2026020'), false);
+        assert.strictEqual(isValidDate('202602011'), false);
+    });
 });

--- a/test/backtestService.test.js
+++ b/test/backtestService.test.js
@@ -73,6 +73,16 @@ suite('backtestService', function () {
         assert.ok(updated.includes('RiskPercentage=1.25||1||0.5||10||Y'));
     });
 
+    test('normalizes compact YYYYMMDD dates to the dotted form MT5 expects', function () {
+        const updated = updateTesterIniContent(testerIni(), {
+            fromDate: '20260201',
+            toDate: '20260430',
+        });
+
+        assert.ok(updated.includes('FromDate=2026.02.01'));
+        assert.ok(updated.includes('ToDate=2026.04.30'));
+    });
+
     test('finds tester agent log directory from MQL5 root terminal id', function () {
         const mql5Root = path.join(tempDir, 'MetaQuotes', 'Terminal', 'ABCDEF', 'MQL5');
         const logDir = path.join(tempDir, 'MetaQuotes', 'Tester', 'ABCDEF', 'Agent-127.0.0.1-3000', 'logs');

--- a/test/backtestService.test.js
+++ b/test/backtestService.test.js
@@ -83,6 +83,18 @@ suite('backtestService', function () {
         assert.ok(updated.includes('ToDate=2026.04.30'));
     });
 
+    test('does not crash on non-string date values in params', function () {
+        assert.doesNotThrow(() => {
+            const updated = updateTesterIniContent(testerIni(), {
+                fromDate: 20260201,
+                toDate: 20260430,
+            });
+            // Numeric input is passed through unchanged rather than slice()-ing.
+            assert.ok(updated.includes('FromDate=20260201'));
+            assert.ok(updated.includes('ToDate=20260430'));
+        });
+    });
+
     test('finds tester agent log directory from MQL5 root terminal id', function () {
         const mql5Root = path.join(tempDir, 'MetaQuotes', 'Terminal', 'ABCDEF', 'MQL5');
         const logDir = path.join(tempDir, 'MetaQuotes', 'Tester', 'ABCDEF', 'Agent-127.0.0.1-3000', 'logs');


### PR DESCRIPTION
parseMqlDate now accepts the compact YYYYMMDD form used in MT5 tester INI
filenames in addition to the dotted YYYY.MM.DD form. Dates are normalized
to the canonical dotted form before being written to tester.ini, so MT5
always receives a valid FromDate/ToDate. Input box hints mention both forms.

Closes #51

https://claude.ai/code/session_01PuDZ6m3bt55vDELeA1scSU