### PR TITLE
Add backtest startup watchdog and launch diagnostics (#49)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "type": "git",
         "url": "https://github.com/pungggi/MQL_clangd"
     },
-    "main": "./src/extension.js",
+    "main": "./dist/extension.js",
     "activationEvents": [],
     "contributes": {
         "debuggers": [
@@ -280,6 +280,12 @@
                     "type": "string",
                     "default": "",
                     "markdownDescription": "Optional Strategy Tester agent log directory override. Leave empty to auto-detect from the MQL5 data folder. Supports `${workspaceFolder}`, `~`, and relative paths."
+                },
+                "mql_tools.Backtest.StartupGraceSeconds": {
+                    "type": "number",
+                    "default": 45,
+                    "minimum": 5,
+                    "markdownDescription": "Seconds to wait after launching MT5 before warning that no Strategy Tester log activity has been detected. A diagnostic notification (with the resolved terminal, `tester.ini`, and watched log-directory paths) is shown once if MT5 never starts writing logs, so a misconfigured run no longer spins silently. Polling continues until the run completes or times out."
                 },
                 "mql_tools.Backtest.NodePath": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "type": "git",
         "url": "https://github.com/pungggi/MQL_clangd"
     },
-    "main": "./dist/extension.js",
+    "main": "./src/extension.js",
     "activationEvents": [],
     "contributes": {
         "debuggers": [

--- a/src/backtestRunner.js
+++ b/src/backtestRunner.js
@@ -32,6 +32,7 @@ const POLL_INTERVAL_MS = 2000;
 const MAX_POLL_TIME_MS = 10 * 60 * 1000;
 const DEFAULT_STARTUP_GRACE_SECONDS = 45;
 const STARTUP_GRACE_SETTING = 'Backtest.StartupGraceSeconds';
+const MIN_STARTUP_GRACE_SECONDS = 5;
 const TERMINAL_SETTING_ID = 'mql_tools.Terminal.Terminal5Dir';
 const TESTER_LOG_DIR_SETTING = 'Backtest.TesterLogDir';
 const TESTER_LOG_DIR_SETTING_ID = `mql_tools.${TESTER_LOG_DIR_SETTING}`;
@@ -226,6 +227,18 @@ function getSilentParameters(mql5Root, eaName) {
 // Execute & monitor
 // ---------------------------------------------------------------------------
 
+/**
+ * Coerces the configured startup grace period into a sane millisecond value.
+ * Falls back to the default when the setting is missing, non-numeric, or
+ * non-finite (e.g. mistyped in settings) and clamps to a minimum floor so a
+ * tiny or negative value can't make the watchdog fire immediately.
+ */
+function resolveStartupGraceMs(rawSeconds) {
+    const seconds = rawSeconds === undefined || rawSeconds === null ? DEFAULT_STARTUP_GRACE_SECONDS : Number(rawSeconds);
+    if (!Number.isFinite(seconds)) return DEFAULT_STARTUP_GRACE_SECONDS * 1000;
+    return Math.max(MIN_STARTUP_GRACE_SECONDS, seconds) * 1000;
+}
+
 async function executeBacktest(eaName, params, options) {
     const startResult = await startBacktest({ eaName, params, ...options });
     if (!startResult.started) {
@@ -235,7 +248,7 @@ async function executeBacktest(eaName, params, options) {
 
     const isWine = !!options.useWine;
     const diagnostics = startResult.diagnostics || null;
-    const startupGraceMs = (options.startupGraceSeconds ?? DEFAULT_STARTUP_GRACE_SECONDS) * 1000;
+    const startupGraceMs = resolveStartupGraceMs(options.startupGraceSeconds);
     return vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
@@ -433,5 +446,6 @@ module.exports = {
     parseMqlDate,
     isValidDate,
     shouldTriggerWatchdog,
+    resolveStartupGraceMs,
     TESTER_LOG_DIR_SETTING_ID,
 };

--- a/src/backtestRunner.js
+++ b/src/backtestRunner.js
@@ -16,6 +16,7 @@ const {
     getBacktestStatus,
     cancelBacktest,
     cancelAllBacktests,
+    findLatestTesterLog,
 } = require('./backtestService');
 const {
     isWineEnabled,
@@ -24,10 +25,13 @@ const {
     getWineEnv,
     validateWinePath,
     validateWineSetup,
+    showOutputChannel,
 } = require('./wineHelper');
 
 const POLL_INTERVAL_MS = 2000;
 const MAX_POLL_TIME_MS = 10 * 60 * 1000;
+const DEFAULT_STARTUP_GRACE_SECONDS = 45;
+const STARTUP_GRACE_SETTING = 'Backtest.StartupGraceSeconds';
 const TERMINAL_SETTING_ID = 'mql_tools.Terminal.Terminal5Dir';
 const TESTER_LOG_DIR_SETTING = 'Backtest.TesterLogDir';
 const TESTER_LOG_DIR_SETTING_ID = `mql_tools.${TESTER_LOG_DIR_SETTING}`;
@@ -230,14 +234,51 @@ async function executeBacktest(eaName, params, options) {
     }
 
     const isWine = !!options.useWine;
+    const diagnostics = startResult.diagnostics || null;
+    const startupGraceMs = (options.startupGraceSeconds ?? DEFAULT_STARTUP_GRACE_SECONDS) * 1000;
     return vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
             title: `Backtest: ${eaName} on ${params.symbol}`,
             cancellable: true,
         },
-        async (progress, token) => monitorBacktest(options.mql5Root, eaName, progress, token, isWine),
+        async (progress, token) => monitorBacktest(options.mql5Root, eaName, progress, token, {
+            isWine,
+            diagnostics,
+            startupGraceMs,
+        }),
     );
+}
+
+/**
+ * Decides whether the startup watchdog should fire. It triggers once, after the
+ * grace period elapses, when the watched tester-log directory shows no new
+ * activity since launch — the signature of a misconfigured run that would
+ * otherwise spin silently until MAX_POLL_TIME_MS.
+ */
+function shouldTriggerWatchdog(elapsedMs, graceMs, baselineMtimeMs, currentMtimeMs, alreadyShown) {
+    if (alreadyShown) return false;
+    if (elapsedMs < graceMs) return false;
+    return currentMtimeMs <= baselineMtimeMs;
+}
+
+function showWatchdogNotification(mql5Root, eaName, elapsedSecs, diagnostics) {
+    const lines = [`Backtest "${eaName}": MT5 launched ${elapsedSecs}s ago but no Strategy Tester log activity was detected.`];
+    if (diagnostics) {
+        if (diagnostics.terminalPath) lines.push(`Terminal: ${diagnostics.terminalPath}`);
+        if (diagnostics.testerIniPath) lines.push(`tester.ini: ${diagnostics.testerIniPath}`);
+        if (diagnostics.logDir) lines.push(`Watching: ${diagnostics.logDir}`);
+    }
+    lines.push('MT5 may be writing logs elsewhere (wrong terminal, portable mismatch, different terminal-id).');
+
+    // Fire-and-forget so polling continues while the notification is shown.
+    vscode.window.showWarningMessage(lines.join(' '), 'Show Output', 'Cancel Backtest').then(selection => {
+        if (selection === 'Show Output') {
+            showOutputChannel();
+        } else if (selection === 'Cancel Backtest') {
+            cancelBacktest(mql5Root, eaName);
+        }
+    });
 }
 
 function showStartFailure(eaName, result) {
@@ -248,9 +289,14 @@ function showStartFailure(eaName, result) {
     vscode.window.showErrorMessage(`Failed to start backtest: ${result.message}`);
 }
 
-async function monitorBacktest(mql5Root, eaName, progress, token, isWine = false) {
+async function monitorBacktest(mql5Root, eaName, progress, token, monitorOptions = {}) {
+    const { isWine = false, diagnostics = null, startupGraceMs = DEFAULT_STARTUP_GRACE_SECONDS * 1000 } = monitorOptions;
     const startTime = Date.now();
     progress.report({ message: 'Starting...' });
+
+    const logDir = diagnostics?.logDir || null;
+    const baselineMtimeMs = logDir ? (findLatestTesterLog(logDir)?.mtimeMs ?? 0) : 0;
+    let watchdogShown = false;
 
     while (!token.isCancellationRequested) {
         const elapsed = Date.now() - startTime;
@@ -271,7 +317,17 @@ async function monitorBacktest(mql5Root, eaName, progress, token, isWine = false
             return false;
         }
 
-        const secs = Math.round((Date.now() - startTime) / 1000);
+        const elapsedNow = Date.now() - startTime;
+        const secs = Math.round(elapsedNow / 1000);
+
+        if (logDir && !watchdogShown) {
+            const currentMtimeMs = findLatestTesterLog(logDir)?.mtimeMs ?? 0;
+            if (shouldTriggerWatchdog(elapsedNow, startupGraceMs, baselineMtimeMs, currentMtimeMs, watchdogShown)) {
+                watchdogShown = true;
+                showWatchdogNotification(mql5Root, eaName, secs, diagnostics);
+            }
+        }
+
         progress.report({ message: `Running... (${secs}s)` });
     }
 
@@ -349,6 +405,7 @@ async function runBacktest(context, opts) {
     if (!params) return;
 
     const portableMode = config.get('Metaeditor.Portable5', false);
+    const startupGraceSeconds = config.get(STARTUP_GRACE_SETTING, DEFAULT_STARTUP_GRACE_SECONDS);
 
     const completed = await executeBacktest(eaName, params, {
         mql5Root,
@@ -359,6 +416,7 @@ async function runBacktest(context, opts) {
         winePrefix,
         wineEnv,
         portableMode,
+        startupGraceSeconds,
     });
 
     if (completed && autoOpen) vscode.commands.executeCommand('mql_tools.openTradeReport');
@@ -374,5 +432,6 @@ module.exports = {
     resolveBacktestPathSetting,
     parseMqlDate,
     isValidDate,
+    shouldTriggerWatchdog,
     TESTER_LOG_DIR_SETTING_ID,
 };

--- a/src/backtestService.js
+++ b/src/backtestService.js
@@ -448,7 +448,15 @@ async function startBacktest(options) {
 
     child.unref();
     wineLog(`[Backtest] Launch mode: windows | PID: ${child.pid}`);
-    return { started: true, pid: child.pid, config: effectiveConfig };
+    wineLog(`[Backtest] Terminal: ${terminalPath}`);
+    wineLog(`[Backtest] Config (tester.ini): ${mql5TesterIni}`);
+    wineLog(`[Backtest] Tester log dir: ${logDir}`);
+    return {
+        started: true,
+        pid: child.pid,
+        config: effectiveConfig,
+        diagnostics: { terminalPath, testerIniPath: mql5TesterIni, logDir },
+    };
 }
 
 /**
@@ -485,6 +493,7 @@ async function startBacktestWine(ctx) {
     wineLog('[Backtest] Launch mode: wine');
     wineLog(`[Backtest] Terminal (host): ${terminalPath}`);
     wineLog(`[Backtest] Terminal (wine): ${termResult.path}`);
+    wineLog(`[Backtest] Config (tester.ini host): ${mql5TesterIni}`);
     wineLog(`[Backtest] Config  (wine): /config:${iniResult.path}`);
     wineLog(`[Backtest] Tester log dir: ${logDir}`);
 
@@ -510,7 +519,12 @@ async function startBacktestWine(ctx) {
     });
 
     wineLog(`[Backtest] Launcher PID: ${result.pid} (Wine — best-effort cancellation)`);
-    return { started: true, pid: result.pid, config: effectiveConfig };
+    return {
+        started: true,
+        pid: result.pid,
+        config: effectiveConfig,
+        diagnostics: { terminalPath, testerIniPath: mql5TesterIni, logDir },
+    };
 }
 
 function getBacktestStatus(mql5Root, eaName) {

--- a/src/wineHelper.js
+++ b/src/wineHelper.js
@@ -21,6 +21,16 @@ function setOutputChannel(channel) {
 }
 
 /**
+ * Reveals the diagnostics output channel (if available).
+ * @param {boolean} [preserveFocus=true]
+ */
+function showOutputChannel(preserveFocus = true) {
+    if (outputChannel) {
+        outputChannel.show(preserveFocus);
+    }
+}
+
+/**
  * Logs a message to the output channel (if available) and console.
  * @param {string} message 
  */
@@ -496,6 +506,7 @@ async function execWineBatch(programWinPath, args, wineBinary, winePrefix, wineE
 
 module.exports = {
     setOutputChannel,
+    showOutputChannel,
     isWineInstalled,
     validateWinePath,
     toWineWindowsPath,

--- a/test/backtestRunner.test.js
+++ b/test/backtestRunner.test.js
@@ -9,6 +9,7 @@ const {
     parseMqlDate,
     isValidDate,
     shouldTriggerWatchdog,
+    resolveStartupGraceMs,
 } = require('../src/backtestRunner');
 
 suite('backtestRunner — internal runner helpers', function () {
@@ -67,5 +68,35 @@ suite('backtestRunner — startup watchdog', function () {
 
     test('only fires once (suppressed after it has been shown)', function () {
         assert.strictEqual(shouldTriggerWatchdog(GRACE_MS + 10000, GRACE_MS, 1000, 1000, true), false);
+    });
+});
+
+suite('backtestRunner — startup grace resolution', function () {
+    const DEFAULT_MS = 45 * 1000;
+    const MIN_MS = 5 * 1000;
+
+    test('uses the default when the setting is missing', function () {
+        assert.strictEqual(resolveStartupGraceMs(undefined), DEFAULT_MS);
+        assert.strictEqual(resolveStartupGraceMs(null), DEFAULT_MS);
+    });
+
+    test('converts a valid numeric setting to milliseconds', function () {
+        assert.strictEqual(resolveStartupGraceMs(90), 90 * 1000);
+    });
+
+    test('falls back to the default for non-finite values', function () {
+        assert.strictEqual(resolveStartupGraceMs(NaN), DEFAULT_MS);
+        assert.strictEqual(resolveStartupGraceMs('not-a-number'), DEFAULT_MS);
+        assert.strictEqual(resolveStartupGraceMs(Infinity), DEFAULT_MS);
+    });
+
+    test('clamps tiny or negative values to the minimum floor', function () {
+        assert.strictEqual(resolveStartupGraceMs(-10), MIN_MS);
+        assert.strictEqual(resolveStartupGraceMs(0), MIN_MS);
+        assert.strictEqual(resolveStartupGraceMs(1), MIN_MS);
+    });
+
+    test('accepts numeric strings from settings', function () {
+        assert.strictEqual(resolveStartupGraceMs('60'), 60 * 1000);
     });
 });

--- a/test/backtestRunner.test.js
+++ b/test/backtestRunner.test.js
@@ -8,6 +8,7 @@ const {
     resolveBacktestPathSetting,
     parseMqlDate,
     isValidDate,
+    shouldTriggerWatchdog,
 } = require('../src/backtestRunner');
 
 suite('backtestRunner — internal runner helpers', function () {
@@ -43,5 +44,28 @@ suite('backtestRunner — internal runner helpers', function () {
         assert.strictEqual(parseMqlDate('invalid-date'), null);
         assert.strictEqual(parseMqlDate('2025.13.01'), null);
         assert.strictEqual(parseMqlDate('2025.02.30'), null);
+    });
+});
+
+suite('backtestRunner — startup watchdog', function () {
+    const GRACE_MS = 45 * 1000;
+
+    test('does not trigger before the grace period elapses', function () {
+        assert.strictEqual(shouldTriggerWatchdog(10000, GRACE_MS, 0, 0, false), false);
+    });
+
+    test('triggers after the grace period when no log activity is seen', function () {
+        // currentMtime unchanged from the baseline -> MT5 never wrote.
+        assert.strictEqual(shouldTriggerWatchdog(GRACE_MS, GRACE_MS, 1000, 1000, false), true);
+        assert.strictEqual(shouldTriggerWatchdog(GRACE_MS + 5000, GRACE_MS, 0, 0, false), true);
+    });
+
+    test('does not trigger when the tester log shows fresh activity', function () {
+        // currentMtime advanced past the baseline -> MT5 is writing logs.
+        assert.strictEqual(shouldTriggerWatchdog(GRACE_MS + 5000, GRACE_MS, 1000, 2000, false), false);
+    });
+
+    test('only fires once (suppressed after it has been shown)', function () {
+        assert.strictEqual(shouldTriggerWatchdog(GRACE_MS + 10000, GRACE_MS, 1000, 1000, true), false);
     });
 });


### PR DESCRIPTION
When MT5 launches but never writes to the watched Strategy Tester agent
log directory, monitorBacktest previously showed only a spinning progress
notification for the full 10-minute poll window with no hint where to look.

- Add a configurable startup grace period (mql_tools.Backtest.StartupGraceSeconds,
  default 45s). After it elapses with no tester-log activity, surface a warning
  notification listing the resolved terminal path, the written tester.ini path,
  and the watched agent log directory, with Show Output and Cancel Backtest actions.
- Polling continues after the warning; the run can be cancelled from the notification.
- Log all four diagnostic paths to the output channel at launch on the native
  Windows path too (previously only the Wine path logged them) and return them
  as diagnostics from startBacktest.
- Add showOutputChannel helper to wineHelper for the Show Output action.

https://claude.ai/code/session_01PAzsnHNhrzBTFNmjr3MA4W