### PR TITLE
Backtest: log launch args and include them in watchdog diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mql-clangd",
-    "version": "1.1.53",
+    "version": "1.1.59",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mql-clangd",
-            "version": "1.1.53",
+            "version": "1.1.59",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
                 "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "type": "git",
         "url": "https://github.com/pungggi/MQL_clangd"
     },
-    "main": "./src/extension.js",
+    "main": "./dist/extension.js",
     "activationEvents": [],
     "contributes": {
         "debuggers": [

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "type": "git",
         "url": "https://github.com/pungggi/MQL_clangd"
     },
-    "main": "./dist/extension.js",
+    "main": "./src/extension.js",
     "activationEvents": [],
     "contributes": {
         "debuggers": [

--- a/src/backtestRunner.js
+++ b/src/backtestRunner.js
@@ -372,6 +372,7 @@ function showWatchdogNotification(mql5Root, eaName, elapsedSecs, diagnostics) {
     const lines = [`Backtest "${eaName}": MT5 launched ${elapsedSecs}s ago but no Strategy Tester log activity was detected.`];
     if (diagnostics) {
         if (diagnostics.terminalPath) lines.push(`Terminal: ${diagnostics.terminalPath}`);
+        if (diagnostics.launchArgs) lines.push(`Args: ${diagnostics.launchArgs.join(' ')}`);
         if (diagnostics.testerIniPath) lines.push(`tester.ini: ${diagnostics.testerIniPath}`);
         if (diagnostics.logDir) lines.push(`Watching: ${diagnostics.logDir}`);
     }

--- a/src/backtestRunner.js
+++ b/src/backtestRunner.js
@@ -372,7 +372,7 @@ function showWatchdogNotification(mql5Root, eaName, elapsedSecs, diagnostics) {
     const lines = [`Backtest "${eaName}": MT5 launched ${elapsedSecs}s ago but no Strategy Tester log activity was detected.`];
     if (diagnostics) {
         if (diagnostics.terminalPath) lines.push(`Terminal: ${diagnostics.terminalPath}`);
-        if (diagnostics.launchArgs) lines.push(`Args: ${diagnostics.launchArgs.join(' ')}`);
+        if (diagnostics.launchArgs) lines.push(`Args: ${diagnostics.launchArgs.map(a => a.includes(' ') ? `"${a}"` : a).join(' ')}`);
         if (diagnostics.testerIniPath) lines.push(`tester.ini: ${diagnostics.testerIniPath}`);
         if (diagnostics.logDir) lines.push(`Watching: ${diagnostics.logDir}`);
     }

--- a/src/backtestService.js
+++ b/src/backtestService.js
@@ -529,7 +529,7 @@ async function startBacktest(options) {
     child.unref();
     wineLog(`[Backtest] Launch mode: windows | PID: ${child.pid}`);
     wineLog(`[Backtest] Terminal: ${terminalPath}`);
-    wineLog(`[Backtest] Args: ${launchArgs.join(' ')}`);
+    wineLog(`[Backtest] Args: ${launchArgs.map(a => a.includes(' ') ? `"${a}"` : a).join(' ')}`);
     wineLog(`[Backtest] Config (tester.ini): ${mql5TesterIni}`);
     wineLog(`[Backtest] Tester log dir: ${logDir}`);
     return {
@@ -574,6 +574,7 @@ async function startBacktestWine(ctx) {
     wineLog('[Backtest] Launch mode: wine');
     wineLog(`[Backtest] Terminal (host): ${terminalPath}`);
     wineLog(`[Backtest] Terminal (wine): ${termResult.path}`);
+    wineLog(`[Backtest] Args: ${args.map(a => a.includes(' ') ? `"${a}"` : a).join(' ')}`);
     wineLog(`[Backtest] Config (tester.ini host): ${mql5TesterIni}`);
     wineLog(`[Backtest] Config  (wine): /config:${iniResult.path}`);
     wineLog(`[Backtest] Tester log dir: ${logDir}`);

--- a/src/backtestService.js
+++ b/src/backtestService.js
@@ -529,13 +529,14 @@ async function startBacktest(options) {
     child.unref();
     wineLog(`[Backtest] Launch mode: windows | PID: ${child.pid}`);
     wineLog(`[Backtest] Terminal: ${terminalPath}`);
+    wineLog(`[Backtest] Args: ${launchArgs.join(' ')}`);
     wineLog(`[Backtest] Config (tester.ini): ${mql5TesterIni}`);
     wineLog(`[Backtest] Tester log dir: ${logDir}`);
     return {
         started: true,
         pid: child.pid,
         config: effectiveConfig,
-        diagnostics: { terminalPath, testerIniPath: mql5TesterIni, logDir },
+        diagnostics: { terminalPath, testerIniPath: mql5TesterIni, logDir, launchArgs },
     };
 }
 
@@ -603,7 +604,7 @@ async function startBacktestWine(ctx) {
         started: true,
         pid: result.pid,
         config: effectiveConfig,
-        diagnostics: { terminalPath, testerIniPath: mql5TesterIni, logDir },
+        diagnostics: { terminalPath, testerIniPath: mql5TesterIni, logDir, launchArgs: args },
     };
 }
 


### PR DESCRIPTION
The output channel and watchdog notification now show the actual
arguments passed to terminal64.exe (e.g. /config:... /portable),
making it possible to confirm whether the /portable flag was applied
for portable MT5 setups without guessing.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wbv6RJFdAi4HeFnqjwhNnd