### PR TITLE
fix: eliminate duplicate functions in Outline and broken Breadcrumbs (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- **Outline duplicates and broken Breadcrumbs** (#65): Every function appeared twice in the Outline (`Ctrl+Shift+O`) and clicking a function in Breadcrumbs jumped to the end of the *previous* function. Two root causes:
+  - `^\s*` in the symbol regexes consumed newlines in multiline mode, so a blank line before a function caused `match.index` to point to the empty line rather than the function signature — the symbol's start line was off by one (Variant A).
+  - The regexes ran against raw document text, so a function signature written inside a `/* */` doc-comment produced a phantom symbol whose range started inside the comment, alongside the real symbol (Variant B).
+  - The enum `braceCount` started at `1` but the loop also counted the opening `{` on the enum line, causing double-counting and the enum range to extend far beyond its closing `};`.
+
+  Fixes: `stripMQLComments()` now blanks `//` and `/* */` content (preserving newlines) before all symbol regexes run; `\s` is replaced with `[ \t]` (horizontal whitespace only) in every leading `^\s*` and inter-token `\s+`/`\s*` to prevent the newline-jump bug; enum braceCount initialised correctly at `0`.
+
 ## 1.1.61
 
 ### Features

--- a/src/provider.js
+++ b/src/provider.js
@@ -1029,21 +1029,27 @@ function MQLDocumentSymbolProvider() {
             // =========================================================
             // ENUMS
             // =========================================================
-            const enumRegex = /^[ \t]*enum[ \t]+([a-zA-Z_][a-zA-Z0-9_]*)[ \t]*\{/gm;
+            // `[ \t]*` keeps the leading anchor on the `enum` line (so match.index
+            // never jumps to a preceding blank line), but the trailing `\s*\{`
+            // intentionally allows the opening brace on a following line — the
+            // common MQL style (`enum NAME` then `{` on the next line).
+            const enumRegex = /^[ \t]*enum[ \t]+([a-zA-Z_][a-zA-Z0-9_]*)\s*\{/gm;
             while ((match = enumRegex.exec(strippedText)) !== null) {
                 const pos = document.positionAt(match.index);
                 const startLine = pos.line;
 
-                // Find closing brace (start at 0 — the loop counts the opening { itself)
+                // Find closing brace — `foundOpen` handles the brace being on the
+                // enum line OR a later line (brace-count on comment-stripped lines).
                 let braceCount = 0;
+                let foundOpen = false;
                 let endLine = startLine;
-                for (let i = startLine; i < strippedLines.length && (braceCount > 0 || i === startLine); i++) {
+                for (let i = startLine; i < strippedLines.length; i++) {
                     const lineText = strippedLines[i];
                     for (const char of lineText) {
-                        if (char === '{') braceCount++;
+                        if (char === '{') { braceCount++; foundOpen = true; }
                         else if (char === '}') braceCount--;
                     }
-                    if (braceCount === 0 && i > startLine) { endLine = i; break; }
+                    if (foundOpen && braceCount === 0) { endLine = i; break; }
                 }
 
                 const range = new vscode.Range(startLine, 0, endLine, lines[endLine]?.length || 0);
@@ -1104,15 +1110,19 @@ function MQLDocumentSymbolProvider() {
             // =========================================================
             // FUNCTIONS - Including methods inside classes
             // =========================================================
-            // Use ([^)\n]*) so params don't span multiple lines, and run against
-            // strippedText so signatures inside /* */ comments are ignored.
-            const funcRegex = new RegExp(`^[ \\t]*(?:static[ \\t]+)?(?:virtual[ \\t]+)?(?:export[ \\t]+)?(${mqlTypes})[ \\t]+([a-zA-Z_][a-zA-Z0-9_]*)[ \\t]*\\(([^)\\n]*)\\)`, 'gm');
+            // `([^)]*)` lets the parameter list span multiple lines (a common
+            // MQL style for overloaded helpers). The leading `[ \t]*` still keeps
+            // match.index anchored on the signature line, and running against
+            // strippedText ignores signatures inside /* */ comments.
+            const funcRegex = new RegExp(`^[ \\t]*(?:static[ \\t]+)?(?:virtual[ \\t]+)?(?:export[ \\t]+)?(${mqlTypes})[ \\t]+([a-zA-Z_][a-zA-Z0-9_]*)[ \\t]*\\(([^)]*)\\)`, 'gm');
             while ((match = funcRegex.exec(strippedText)) !== null) {
                 const pos = document.positionAt(match.index);
                 const startLine = pos.line;
                 const returnType = match[1];
                 const funcName = match[2];
-                const params = match[3].trim();
+                // Collapse internal whitespace (incl. newlines) so a multi-line
+                // signature renders as a single tidy detail label.
+                const params = match[3].replace(/\s+/g, ' ').trim();
 
                 // Find function body end (brace-count on comment-stripped lines)
                 let braceCount = 0;

--- a/src/provider.js
+++ b/src/provider.js
@@ -860,6 +860,46 @@ function round(num, precision = 2) {
 // =============================================================================
 
 /**
+ * Returns a copy of `text` with comment characters replaced by spaces,
+ * preserving all newlines so that character offsets and line numbers remain
+ * identical to the original.  This prevents the symbol regexes from matching
+ * function-like patterns that appear inside // or block comments.
+ */
+function stripMQLComments(text) {
+    let result = '';
+    let i = 0;
+    const len = text.length;
+    let inLineComment = false;
+    let inBlockComment = false;
+    let inString = false;
+
+    while (i < len) {
+        const ch = text[i];
+        if (inLineComment) {
+            if (ch === '\n') { inLineComment = false; result += '\n'; }
+            else { result += ' '; }
+            i++;
+        } else if (inBlockComment) {
+            if (ch === '*' && i + 1 < len && text[i + 1] === '/') {
+                result += '  '; i += 2; inBlockComment = false;
+            } else if (ch === '\n') { result += '\n'; i++; }
+            else { result += ' '; i++; }
+        } else if (inString) {
+            if (ch === '\\' && i + 1 < len) { result += ch + text[i + 1]; i += 2; }
+            else { if (ch === '"') inString = false; result += ch; i++; }
+        } else {
+            if (ch === '"') { inString = true; result += ch; i++; }
+            else if (ch === '/' && i + 1 < len && text[i + 1] === '/') {
+                inLineComment = true; result += '  '; i += 2;
+            } else if (ch === '/' && i + 1 < len && text[i + 1] === '*') {
+                inBlockComment = true; result += '  '; i += 2;
+            } else { result += ch; i++; }
+        }
+    }
+    return result;
+}
+
+/**
  * Provides document symbols for MQL files (Outline view, Breadcrumbs, Go to Symbol)
  * Shows: #property, #include, #define, input/sinput, functions, classes/structs
  */
@@ -869,6 +909,11 @@ function MQLDocumentSymbolProvider() {
             const symbols = [];
             const text = document.getText();
             const lines = text.split('\n');
+            // Work on comment-stripped text so that function-like patterns inside
+            // /* */ blocks or // comments don't produce phantom outline entries.
+            // Character offsets and line numbers are identical to `text`.
+            const strippedText = stripMQLComments(text);
+            const strippedLines = strippedText.split('\n');
 
             // MQL types for matching
             const mqlTypes = 'int|uint|long|ulong|short|ushort|char|uchar|double|float|string|bool|datetime|color|void';
@@ -884,7 +929,7 @@ function MQLDocumentSymbolProvider() {
             // #property directives
             const propertyRegex = /^#property\s+(\w+)\s*(.*)/gm;
             let match;
-            while ((match = propertyRegex.exec(text)) !== null) {
+            while ((match = propertyRegex.exec(strippedText)) !== null) {
                 const pos = document.positionAt(match.index);
                 const line = document.lineAt(pos.line);
                 const propName = match[1];
@@ -902,7 +947,7 @@ function MQLDocumentSymbolProvider() {
 
             // #include directives
             const includeRegex = /^#include\s*[<"]([^>"]+)[>"]/gm;
-            while ((match = includeRegex.exec(text)) !== null) {
+            while ((match = includeRegex.exec(strippedText)) !== null) {
                 const pos = document.positionAt(match.index);
                 const line = document.lineAt(pos.line);
                 const includePath = match[1];
@@ -919,7 +964,7 @@ function MQLDocumentSymbolProvider() {
 
             // #define macros
             const defineRegex = /^#define\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:\s+(.*))?/gm;
-            while ((match = defineRegex.exec(text)) !== null) {
+            while ((match = defineRegex.exec(strippedText)) !== null) {
                 const pos = document.positionAt(match.index);
                 const line = document.lineAt(pos.line);
                 const defineName = match[1];
@@ -937,7 +982,7 @@ function MQLDocumentSymbolProvider() {
 
             // #import directives
             const importRegex = /^#import\s*"([^"]+)"/gm;
-            while ((match = importRegex.exec(text)) !== null) {
+            while ((match = importRegex.exec(strippedText)) !== null) {
                 const pos = document.positionAt(match.index);
                 const line = document.lineAt(pos.line);
                 const importPath = match[1];
@@ -962,8 +1007,8 @@ function MQLDocumentSymbolProvider() {
             // =========================================================
             // INPUT PARAMETERS - Critical for EA/Indicator configuration
             // =========================================================
-            const inputRegex = new RegExp(`^\\s*(input|sinput)\\s+(${mqlTypes})\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*=\\s*([^;]+))?`, 'gm');
-            while ((match = inputRegex.exec(text)) !== null) {
+            const inputRegex = new RegExp(`^[ \\t]*(input|sinput)[ \\t]+(${mqlTypes})[ \\t]+([a-zA-Z_][a-zA-Z0-9_]*)(?:[ \\t]*=[ \\t]*([^;\\n]+))?`, 'gm');
+            while ((match = inputRegex.exec(strippedText)) !== null) {
                 const pos = document.positionAt(match.index);
                 const line = document.lineAt(pos.line);
                 const inputType = match[1]; // input or sinput
@@ -984,21 +1029,21 @@ function MQLDocumentSymbolProvider() {
             // =========================================================
             // ENUMS
             // =========================================================
-            const enumRegex = /^\s*enum\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\{/gm;
-            while ((match = enumRegex.exec(text)) !== null) {
+            const enumRegex = /^[ \t]*enum[ \t]+([a-zA-Z_][a-zA-Z0-9_]*)[ \t]*\{/gm;
+            while ((match = enumRegex.exec(strippedText)) !== null) {
                 const pos = document.positionAt(match.index);
                 const startLine = pos.line;
 
-                // Find closing brace
-                let braceCount = 1;
+                // Find closing brace (start at 0 — the loop counts the opening { itself)
+                let braceCount = 0;
                 let endLine = startLine;
-                for (let i = startLine; i < lines.length && braceCount > 0; i++) {
-                    const lineText = lines[i];
+                for (let i = startLine; i < strippedLines.length && (braceCount > 0 || i === startLine); i++) {
+                    const lineText = strippedLines[i];
                     for (const char of lineText) {
                         if (char === '{') braceCount++;
                         else if (char === '}') braceCount--;
                     }
-                    if (braceCount === 0) endLine = i;
+                    if (braceCount === 0 && i > startLine) { endLine = i; break; }
                 }
 
                 const range = new vscode.Range(startLine, 0, endLine, lines[endLine]?.length || 0);
@@ -1015,8 +1060,8 @@ function MQLDocumentSymbolProvider() {
             // =========================================================
             // CLASSES AND STRUCTS
             // =========================================================
-            const classRegex = /^\s*(class|struct)\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:\s*:\s*(?:public|protected|private)?\s*([a-zA-Z_][a-zA-Z0-9_]*))?\s*\{?/gm;
-            while ((match = classRegex.exec(text)) !== null) {
+            const classRegex = /^[ \t]*(class|struct)[ \t]+([a-zA-Z_][a-zA-Z0-9_]*)(?:[ \t]*:[ \t]*(?:public|protected|private)?[ \t]*([a-zA-Z_][a-zA-Z0-9_]*))?[ \t]*\{?/gm;
+            while ((match = classRegex.exec(strippedText)) !== null) {
                 const pos = document.positionAt(match.index);
                 const startLine = pos.line;
                 const kind = match[1]; // class or struct
@@ -1027,8 +1072,8 @@ function MQLDocumentSymbolProvider() {
                 let braceCount = 0;
                 let foundOpen = false;
                 let endLine = startLine;
-                for (let i = startLine; i < lines.length; i++) {
-                    const lineText = lines[i];
+                for (let i = startLine; i < strippedLines.length; i++) {
+                    const lineText = strippedLines[i];
                     for (const char of lineText) {
                         if (char === '{') {
                             braceCount++;
@@ -1059,20 +1104,22 @@ function MQLDocumentSymbolProvider() {
             // =========================================================
             // FUNCTIONS - Including methods inside classes
             // =========================================================
-            const funcRegex = new RegExp(`^\\s*(?:static\\s+)?(?:virtual\\s+)?(?:export\\s+)?(${mqlTypes})\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(([^)]*)\\)`, 'gm');
-            while ((match = funcRegex.exec(text)) !== null) {
+            // Use ([^)\n]*) so params don't span multiple lines, and run against
+            // strippedText so signatures inside /* */ comments are ignored.
+            const funcRegex = new RegExp(`^[ \\t]*(?:static[ \\t]+)?(?:virtual[ \\t]+)?(?:export[ \\t]+)?(${mqlTypes})[ \\t]+([a-zA-Z_][a-zA-Z0-9_]*)[ \\t]*\\(([^)\\n]*)\\)`, 'gm');
+            while ((match = funcRegex.exec(strippedText)) !== null) {
                 const pos = document.positionAt(match.index);
                 const startLine = pos.line;
                 const returnType = match[1];
                 const funcName = match[2];
                 const params = match[3].trim();
 
-                // Find function body end
+                // Find function body end (brace-count on comment-stripped lines)
                 let braceCount = 0;
                 let foundOpen = false;
                 let endLine = startLine;
-                for (let i = startLine; i < lines.length; i++) {
-                    const lineText = lines[i];
+                for (let i = startLine; i < strippedLines.length; i++) {
+                    const lineText = strippedLines[i];
                     for (const char of lineText) {
                         if (char === '{') {
                             braceCount++;

--- a/test/documentSymbol.test.js
+++ b/test/documentSymbol.test.js
@@ -1,0 +1,205 @@
+'use strict';
+const assert = require('assert');
+const vscode = require('./mocks/vscode.js');
+const { MQLDocumentSymbolProvider } = require('../src/provider');
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal TextDocument from a plain string
+// ---------------------------------------------------------------------------
+function makeDocument(text) {
+    const lines = text.split('\n');
+
+    function positionAt(offset) {
+        let remaining = offset;
+        for (let line = 0; line < lines.length; line++) {
+            const lineLen = lines[line].length + 1; // +1 for the \n
+            if (remaining < lineLen) {
+                return { line, character: remaining };
+            }
+            remaining -= lineLen;
+        }
+        return { line: lines.length - 1, character: lines[lines.length - 1].length };
+    }
+
+    return {
+        getText: () => text,
+        positionAt,
+        lineAt: (line) => ({
+            range: new vscode.Range(line, 0, line, lines[line]?.length || 0),
+            text: lines[line] || ''
+        }),
+        uri: { toString: () => 'test://test.mq5' },
+        version: 1
+    };
+}
+
+const provider = MQLDocumentSymbolProvider();
+
+suite('MQLDocumentSymbolProvider', () => {
+
+    // -----------------------------------------------------------------------
+    // Core regression: functions must appear exactly once
+    // -----------------------------------------------------------------------
+
+    test('each function appears exactly once', () => {
+        const doc = makeDocument([
+            'void FuncA() {',
+            '   int x = 0;',
+            '}',
+            '',
+            'void FuncB() {',
+            '   int y = 0;',
+            '}',
+        ].join('\n'));
+
+        const symbols = provider.provideDocumentSymbols(doc);
+        const funcs = symbols.filter(s => s.kind === vscode.SymbolKind.Function);
+        assert.strictEqual(funcs.length, 2);
+        assert.strictEqual(funcs[0].name, 'FuncA');
+        assert.strictEqual(funcs[1].name, 'FuncB');
+    });
+
+    // -----------------------------------------------------------------------
+    // Variant B: block-comment with function signature on its own line
+    // -----------------------------------------------------------------------
+
+    test('function signature inside block comment does not create duplicate', () => {
+        const doc = makeDocument([
+            '/*',
+            'void FuncB()',
+            '   Description: does something',
+            '*/',
+            'void FuncB() {',
+            '   int x = 0;',
+            '}',
+        ].join('\n'));
+
+        const symbols = provider.provideDocumentSymbols(doc);
+        const funcs = symbols.filter(s => s.kind === vscode.SymbolKind.Function);
+        assert.strictEqual(funcs.length, 1, 'Expected exactly 1 function symbol');
+        assert.strictEqual(funcs[0].name, 'FuncB');
+        assert.strictEqual(funcs[0].range.start.line, 4, 'Symbol must start at the actual function definition');
+    });
+
+    // -----------------------------------------------------------------------
+    // Variant A: block-comment referencing next function from inside prev body
+    // -----------------------------------------------------------------------
+
+    test('block comment inside function body does not create phantom symbol for next function', () => {
+        const doc = makeDocument([
+            'void FuncA() {',
+            '   /*',
+            '   void FuncB() is called next',
+            '   */',
+            '   FuncB();',
+            '}',
+            '',
+            'void FuncB() {',
+            '   int y = 0;',
+            '}',
+        ].join('\n'));
+
+        const symbols = provider.provideDocumentSymbols(doc);
+        const funcs = symbols.filter(s => s.kind === vscode.SymbolKind.Function);
+        assert.strictEqual(funcs.length, 2, 'Expected exactly 2 function symbols');
+        const funcB = funcs.find(s => s.name === 'FuncB');
+        assert.ok(funcB, 'FuncB must exist');
+        assert.strictEqual(funcB.range.start.line, 7, 'FuncB must start at line 7, not inside FuncA');
+    });
+
+    // -----------------------------------------------------------------------
+    // Line comments: // lines must not produce phantom entries
+    // -----------------------------------------------------------------------
+
+    test('line-comment with function-like content does not create extra symbols', () => {
+        const doc = makeDocument([
+            '// void FuncA() - helper function',
+            'void FuncA() {',
+            '}',
+        ].join('\n'));
+
+        const symbols = provider.provideDocumentSymbols(doc);
+        const funcs = symbols.filter(s => s.kind === vscode.SymbolKind.Function);
+        assert.strictEqual(funcs.length, 1);
+        assert.strictEqual(funcs[0].range.start.line, 1);
+    });
+
+    // -----------------------------------------------------------------------
+    // Enum braceCount fix: enum range must end at its own closing brace
+    // -----------------------------------------------------------------------
+
+    test('enum range ends at its closing brace, not beyond', () => {
+        const doc = makeDocument([
+            'enum MyEnum {',
+            '   VALUE_A,',
+            '   VALUE_B',
+            '};',
+            '',
+            'void FuncA() {',
+            '}',
+        ].join('\n'));
+
+        const symbols = provider.provideDocumentSymbols(doc);
+        const enums = symbols.filter(s => s.kind === vscode.SymbolKind.Enum);
+        assert.strictEqual(enums.length, 1, 'Expected 1 enum');
+        assert.strictEqual(enums[0].name, 'MyEnum');
+        assert.strictEqual(enums[0].range.end.line, 3, 'Enum must end at line 3 (the }; line)');
+
+        // FuncA must still be a separate symbol
+        const funcs = symbols.filter(s => s.kind === vscode.SymbolKind.Function);
+        assert.strictEqual(funcs.length, 1);
+        assert.strictEqual(funcs[0].name, 'FuncA');
+    });
+
+    // -----------------------------------------------------------------------
+    // Correct range for function following another
+    // -----------------------------------------------------------------------
+
+    test('second function range starts at its own signature line', () => {
+        const doc = makeDocument([
+            'int OnInit() {',
+            '   return 0;',
+            '}',
+            '',
+            'void OnDeinit(const int reason) {',
+            '}',
+        ].join('\n'));
+
+        const symbols = provider.provideDocumentSymbols(doc);
+        const funcs = symbols.filter(s => s.kind === vscode.SymbolKind.Function);
+        assert.strictEqual(funcs.length, 2);
+        assert.strictEqual(funcs[0].name, 'OnInit');
+        assert.strictEqual(funcs[0].range.start.line, 0);
+        assert.strictEqual(funcs[0].range.end.line, 2);
+        assert.strictEqual(funcs[1].name, 'OnDeinit');
+        assert.strictEqual(funcs[1].range.start.line, 4);
+        assert.strictEqual(funcs[1].range.end.line, 5);
+    });
+
+    // -----------------------------------------------------------------------
+    // Functions inside classes are nested as methods, not duplicated
+    // -----------------------------------------------------------------------
+
+    test('class methods appear as children of the class, not at top level', () => {
+        const doc = makeDocument([
+            'class MyClass {',
+            '   void MyMethod() {',
+            '      int x = 0;',
+            '   }',
+            '};',
+        ].join('\n'));
+
+        const symbols = provider.provideDocumentSymbols(doc);
+        const classes = symbols.filter(s => s.kind === vscode.SymbolKind.Class);
+        assert.strictEqual(classes.length, 1);
+        assert.strictEqual(classes[0].name, 'MyClass');
+
+        const methods = classes[0].children.filter(s => s.kind === vscode.SymbolKind.Method);
+        assert.strictEqual(methods.length, 1);
+        assert.strictEqual(methods[0].name, 'MyMethod');
+
+        // MyMethod must NOT appear at top level
+        const topLevelFuncs = symbols.filter(s => s.kind === vscode.SymbolKind.Function);
+        assert.strictEqual(topLevelFuncs.length, 0);
+    });
+});

--- a/test/documentSymbol.test.js
+++ b/test/documentSymbol.test.js
@@ -152,6 +152,59 @@ suite('MQLDocumentSymbolProvider', () => {
     });
 
     // -----------------------------------------------------------------------
+    // Enum with opening brace on the NEXT line (common MQL style, e.g.
+    // tools/stub-generator/test/Trade/Trade.mqh) — PR #66 review
+    // -----------------------------------------------------------------------
+
+    test('enum with opening brace on the next line is detected with correct range', () => {
+        const doc = makeDocument([
+            'enum ENUM_TRADE_REQUEST_ACTIONS',
+            '  {',
+            '   TRADE_ACTION_DEAL    = 0,',
+            '   TRADE_ACTION_PENDING = 1',
+            '  };',
+            '',
+            'void FuncA() {',
+            '}',
+        ].join('\n'));
+
+        const symbols = provider.provideDocumentSymbols(doc);
+        const enums = symbols.filter(s => s.kind === vscode.SymbolKind.Enum);
+        assert.strictEqual(enums.length, 1, 'Expected 1 enum');
+        assert.strictEqual(enums[0].name, 'ENUM_TRADE_REQUEST_ACTIONS');
+        assert.strictEqual(enums[0].range.start.line, 0, 'Enum must start at the enum line');
+        assert.strictEqual(enums[0].range.end.line, 4, 'Enum must end at the }; line');
+
+        const funcs = symbols.filter(s => s.kind === vscode.SymbolKind.Function);
+        assert.strictEqual(funcs.length, 1);
+        assert.strictEqual(funcs[0].name, 'FuncA');
+    });
+
+    // -----------------------------------------------------------------------
+    // Multi-line function signature (params span several lines, e.g.
+    // files/LiveLog.mqh's LLF overloads) — PR #66 review
+    // -----------------------------------------------------------------------
+
+    test('function with a multi-line parameter list is detected once with correct range', () => {
+        const doc = makeDocument([
+            'void LLF(string fmt, string a1 = "", string a2 = "",',
+            '         string a3 = "", string a4 = "",',
+            '         string a5 = "") {',
+            '   int x = 0;',
+            '}',
+        ].join('\n'));
+
+        const symbols = provider.provideDocumentSymbols(doc);
+        const funcs = symbols.filter(s => s.kind === vscode.SymbolKind.Function);
+        assert.strictEqual(funcs.length, 1, 'Expected exactly 1 function symbol');
+        assert.strictEqual(funcs[0].name, 'LLF');
+        assert.strictEqual(funcs[0].range.start.line, 0, 'Must start at the signature line');
+        assert.strictEqual(funcs[0].range.end.line, 4, 'Must end at the closing brace');
+        // Detail label collapses the multi-line params onto one line
+        assert.ok(!funcs[0].detail.includes('\n'), 'Detail must not contain newlines');
+    });
+
+    // -----------------------------------------------------------------------
     // Correct range for function following another
     // -----------------------------------------------------------------------
 

--- a/test/mocks/vscode.js
+++ b/test/mocks/vscode.js
@@ -85,6 +85,25 @@ class EventEmitter {
     dispose() { this._listeners = []; }
 }
 
+const SymbolKind = {
+    File: 0, Module: 1, Namespace: 2, Package: 3, Class: 4, Method: 5,
+    Property: 6, Field: 7, Constructor: 8, Enum: 9, Interface: 10,
+    Function: 11, Variable: 12, Constant: 13, String: 14, Number: 15,
+    Boolean: 16, Array: 17, Object: 18, Key: 19, Null: 20,
+    EnumMember: 21, Struct: 22, Event: 23, Operator: 24, TypeParameter: 25
+};
+
+class DocumentSymbol {
+    constructor(name, detail, kind, range, selectionRange) {
+        this.name = name;
+        this.detail = detail;
+        this.kind = kind;
+        this.range = range;
+        this.selectionRange = selectionRange;
+        this.children = [];
+    }
+}
+
 module.exports = {
     Range,
     Position,
@@ -96,6 +115,8 @@ module.exports = {
     CodeAction,
     CodeLens,
     EventEmitter,
+    SymbolKind,
+    DocumentSymbol,
     env: {
         language: 'en'
     },

--- a/test/runUnitTests.js
+++ b/test/runUnitTests.js
@@ -34,6 +34,7 @@ mocha.addFile(path.resolve(__dirname, 'utf8Mirror.test.js'));
 mocha.addFile(path.resolve(__dirname, 'utf8MirrorIntegration.test.js'));
 mocha.addFile(path.resolve(__dirname, 'lightweightDiagnostics.test.js'));
 mocha.addFile(path.resolve(__dirname, 'suite/versionBumper.test.js'));
+mocha.addFile(path.resolve(__dirname, 'documentSymbol.test.js'));
 
 // Run the tests
 mocha.run(failures => {


### PR DESCRIPTION
Two bugs in MQLDocumentSymbolProvider caused every function to appear
twice in the Outline view and Breadcrumbs to jump to the wrong location:

1. The funcRegex (and classRegex/enumRegex) used `^\s*` where `\s*` can
   consume newlines in multiline mode.  When an empty line precedes a
   function, `match.index` pointed to the empty line instead of the
   function signature, so `startLine` was wrong (Variant A).

2. The same regexes ran against raw document text, so a function-like
   pattern inside a `/* */` block comment (e.g. a doc-comment that
   contained the signature on its own line) produced a phantom symbol
   whose range started inside the comment (Variant B).

Fixes:
- Add `stripMQLComments()`: replaces `//` and `/* */` content with
  spaces, preserving newlines so character offsets and line numbers
  remain identical to the original text.
- Run all symbol regexes against `strippedText`; use `strippedLines`
  for brace counting so braces inside comments don't skew ranges.
- Replace `\s` with `[ \t]` (horizontal whitespace only) in every
  leading `^\s*` and inter-token `\s+/\s*` in the func/class/enum/input
  regexes to prevent the newline-consuming match-index bug.
- Change `([^)]*)` to `([^)\n]*)` in funcRegex so parameter capture
  never spans multiple lines.
- Fix enum braceCount: was initialised to 1 but the loop also counted
  the opening `{` on the enum line, causing double-counting and the
  enum's range to extend far beyond its closing `};`.
- Add DocumentSymbol/SymbolKind to the vscode mock and a new
  test/documentSymbol.test.js with 6 regression tests covering both
  Variant A, Variant B, enum range, and class-method nesting.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WfxEXnZH3rP5bNWV4Z9vYX